### PR TITLE
Creates "ready" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Adds a new command, "ready", which will set the date for the first
+  un-dated changelog entry in the CHANGELOG.md. You may also pass the --date or -d option
+  to specify an alternate date, or to use a date formate other than YYYY-MM-DD.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ $ ./vendor/bin/keep-a-changelog
 
 Currently supported commands include:
 
+- `ready` will set the planned release date for the most recent changelog entry.
+
 - `tag` allows tagging a release based on the latest version discovered in the
   `CHANGELOG.md` file. The tag will contain the changelog entry for that version
   within the commit message.

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -36,6 +36,7 @@ $application->addCommands([
     new EntryCommand('entry:deprecated'),
     new EntryCommand('entry:removed'),
     new EntryCommand('entry:fixed'),
+    new ReadyCommand('ready'),
     new ReleaseCommand('release'),
     new TaggerCommand('tag'),
 ]);

--- a/src/Exception/NoMatchingChangelogDiscoveredException.php
+++ b/src/Exception/NoMatchingChangelogDiscoveredException.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Exception;
+
+use RuntimeException;
+
+class NoMatchingChangelogDiscoveredException extends RuntimeException
+{
+    public static function for(string $changelogFile) : self
+    {
+        return new self(sprintf(
+            'Unable to find un-dated changelog entry in %s',
+            $changelogFile
+        ));
+    }
+}

--- a/src/ReadyCommand.php
+++ b/src/ReadyCommand.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReadyCommand extends Command
+{
+    private const DESCRIPTION = 'In the latest changelog entry, mark the entry ready by setting its release date.';
+
+    private const HELP = <<< 'EOH'
+In the latest changelog entry, mark the entry ready by setting its release date.
+
+If no --date is specified, the current date in YYYY-MM-DD format will be used.
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+        $this->addOption(
+            'date',
+            '-d',
+            InputOption::VALUE_REQUIRED,
+            'Specific date string to use; use this if the date is other than today,'
+            . ' or if you wish to use a different date format.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $date = $input->getOption('date') ?: date('Y-m-d');
+
+        $output->writeln(sprintf(
+            '<info>Setting release date of most recent changelog to "%s"</info>',
+            $date
+        ));
+
+        $changelogFile = sprintf('%s/CHANGELOG.md', realpath(getcwd()));
+
+        (new SetDate())($changelogFile, $date);
+
+        return 0;
+    }
+}

--- a/src/SetDate.php
+++ b/src/SetDate.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use stdClass;
+
+class SetDate
+{
+    public function __invoke(string $changelogFile, string $date) : void
+    {
+        $contents = file($changelogFile);
+        if (false === $contents) {
+            throw Exception\ChangelogFileNotFoundException::at($changelogFile);
+        }
+
+        $indexData = $this->locateInjectionIndex($contents);
+        if (null === $indexData->index) {
+            throw Exception\NoMatchingChangelogDiscoveredException::for($changelogFile);
+        }
+
+        file_put_contents(
+            $changelogFile,
+            implode('', $this->injectDate($contents, $indexData, $date))
+        );
+    }
+
+    private function locateInjectionIndex(array $contents) : stdClass
+    {
+        $action = (object) [
+            'index' => null,
+            'linePrefix' => '',
+        ];
+
+        // @codingStandardsIgnoreStart
+        $regex = '/^(?P<prefix>## \d+\.\d+\.\d+(?:(alpha|beta|rc|dev|patch|pl|a|b|p)\d+)?)\s+-\s+(?:(?!\d{4}-\d{2}-\d{2}).*)/i';
+        // @codingStandardsIgnoreEnd
+
+        foreach ($contents as $index => $line) {
+            if (! preg_match($regex, $line, $matches)) {
+                continue;
+            }
+
+            $action->index = $index;
+            $action->linePrefix = $matches['prefix'];
+            break;
+        }
+
+        return $action;
+    }
+
+    private function injectDate(array $contents, stdClass $indexData, string $date) : array
+    {
+        $replacement = sprintf(
+            "%s - %s\n",
+            $indexData->linePrefix,
+            $date
+        );
+        // Return value of array_splice is an array of the _replaced_ values,
+        // not the array itself
+        array_splice($contents, $indexData->index, 1, $replacement);
+        return $contents;
+    }
+}

--- a/test/SetDateTest.php
+++ b/test/SetDateTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog;
+
+use Phly\KeepAChangelog\Exception;
+use Phly\KeepAChangelog\SetDate;
+use PHPUnit\Framework\TestCase;
+
+class SetDateTest extends TestCase
+{
+    private $tempFile;
+
+    public function tearDown()
+    {
+        if ($this->tempFile && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+    }
+
+    public function testRaisesExceptionWhenChangelogFileNotFound()
+    {
+        $caught = false;
+        set_error_handler(function ($errno, $errstr) {
+            return true;
+        }, E_WARNING);
+        try {
+            (new SetDate())(__DIR__ . '/CHANGELOG.md', date('Y-m-d'));
+        } catch (Exception\ChangelogFileNotFoundException $e) {
+            $caught = $e;
+        } finally {
+            restore_error_handler();
+        }
+        $this->assertInstanceOf(Exception\ChangelogFileNotFoundException::class, $caught);
+    }
+
+    public function testRaisesExceptionIfNoMatchingChangelogDiscovered()
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'KAC');
+        file_put_contents($this->tempFile, file_get_contents(__DIR__ . '/_files/invalid-composer/composer.json'));
+
+        $this->expectException(Exception\NoMatchingChangelogDiscoveredException::class);
+        (new SetDate())($this->tempFile, date('Y-m-d'));
+    }
+
+    public function testSetsDateForFirstChangelogEntry()
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'KAC');
+        file_put_contents($this->tempFile, file_get_contents(__DIR__ . '/_files/CHANGELOG.md'));
+
+        (new SetDate())($this->tempFile, '2018-04-12');
+        $this->assertFileEquals(__DIR__ . '/_files/CHANGELOG-DATED-EXPECTED.md', $this->tempFile);
+    }
+}

--- a/test/_files/CHANGELOG-DATED-EXPECTED.md
+++ b/test/_files/CHANGELOG-DATED-EXPECTED.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 2.0.0 - 2018-04-12
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.


### PR DESCRIPTION
Sets the release date for the most recent CHANGELOG entry. The date used is by default today, in YYYY-MM-DD format. If the `--date` or `-d` option is provided, an arbitrary string or a date in the past or future may be specified.