### PR TITLE
Implements a new "edit" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- Adds a new command, "edit", which will open the most recent changelog entry
+  in an editor. By default, it uses `$EDITOR`, unless an alternate editor
+  is provided via the `--editor` option. It will edit the file `CHANGELOG.md`
+  unless an alternate file is provided via the `--file` option.
+
 - Adds a new command, "ready", which will set the date for the first
   un-dated changelog entry in the CHANGELOG.md. You may also pass the --date or -d option
   to specify an alternate date, or to use a date formate other than YYYY-MM-DD.

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -31,6 +31,7 @@ $application->addCommands([
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump:bugfix'),
     new BumpCommand(BumpCommand::BUMP_MINOR, 'bump:minor'),
     new BumpCommand(BumpCommand::BUMP_MAJOR, 'bump:major'),
+    new EditCommand('edit'),
     new EntryCommand('entry:added'),
     new EntryCommand('entry:changed'),
     new EntryCommand('entry:deprecated'),

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use stdClass;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Edit
+{
+    /**
+     * @todo Allow pulling a specific changelog entry by version.
+     */
+    public function __invoke(OutputInterface $output, string $filename, ?string $editor) : bool
+    {
+        $changelogData = $this->getChangelogEntry($filename);
+        if (! $changelogData) {
+            $output->writeln(sprintf(
+                '<error>Unable to identify a changelog entry in %s; did you specify the correct file?</error>',
+                $filename
+            ));
+            return false;
+        }
+
+        $editor = $editor ?: $this->discoverEditor();
+        $tempFile = $this->createTempFileWithContents($changelogData->contents);
+
+        $status = $this->spawnEditor($output, $editor, $tempFile);
+
+        if (0 !== $status) {
+            $output->writeln(sprintf(
+                '<error>Unable to update %s; editor returned non-success value</error>',
+                $filename
+            ));
+            return false;
+        }
+
+
+        $this->updateChangelogEntry($filename, $tempFile, $changelogData->index, $changelogData->length);
+        return true;
+    }
+
+    /**
+     * Retrieves the first changelog entry in the file.
+     *
+     * If no changelog entry is found, returns null. Otherwise, returns an
+     * anonymous object with the keys:
+     *
+     * - index, indicating the line number where the contents began
+     * - length, the number of lines in the contents
+     * - contents, a string representing the changelog entry found in its entierty
+     */
+    private function getChangelogEntry($filename) : ?stdClass
+    {
+        $contents = file($filename);
+        if (false === $contents) {
+            throw Exception\ChangelogFileNotFoundException::at($filename);
+        }
+
+        $data = (object) [
+            'contents' => '',
+            'index' => null,
+            'length' => 0,
+        ];
+
+        foreach ($contents as $index => $line) {
+            if (preg_match('/^## \d+\.\d+\.\d+/', $line)) {
+                if ($data->index) {
+                    break;
+                }
+                $data->contents = $line;
+                $data->index = $index;
+                $data->length = 1;
+                continue;
+            }
+
+            if (! $data->index) {
+                continue;
+            }
+
+            $data->contents .= $line;
+            $data->length += 1;
+        }
+
+        return $data->index !== null ? $data : null;
+    }
+
+    /**
+     * Creates a temporary file with the changelog contents.
+     */
+    private function createTempFileWithContents(string $contents) : string
+    {
+        $filename = sprintf('%s.md', uniqid('KAC', true));
+        $path = sprintf('%s/%s', sys_get_temp_dir(), $filename);
+        file_put_contents($path, $contents);
+        return $path;
+    }
+
+    /**
+     * Determines the system editor command and returns it.
+     *
+     * Checks for the $EDITOR env variable, returning its value if present.
+     *
+     * If not, it checks to see if we are on a Windows or other type of system,
+     * returning "notepad" or "vi", respecively.
+     */
+    private function discoverEditor() : string
+    {
+        $editor = getenv('EDITOR');
+
+        if ($editor) {
+            return $editor;
+        }
+
+        return isset($_SERVER['OS']) && false !== strpos($_SERVER['OS'], 'indows')
+            ? 'notepad'
+            : 'vi';
+    }
+
+    /**
+     * Spawn an editor to edit the given filename.
+     */
+    public function spawnEditor(OutputInterface $output, string $editor, string $filename) : int
+    {
+        $descriptorspec = array( STDIN, STDOUT, STDERR );
+        $command = sprintf('%s %s', $editor, escapeshellarg($filename));
+
+        $output->writeln(sprintf('<info>Executing "%s"</info>', $command));
+
+        $process = proc_open($command, $descriptorspec, $pipes);
+        return proc_close($process);
+    }
+
+    private function updateChangelogEntry(string $filename, string $tempFile, int $index, int $length)
+    {
+        $contents = file($filename);
+        $replacement = file_get_contents($tempFile);
+        array_splice($contents, $index, $length, $replacement);
+        file_put_contents($filename, implode('', $contents));
+    }
+}

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -128,7 +128,7 @@ class Edit
      */
     public function spawnEditor(OutputInterface $output, string $editor, string $filename) : int
     {
-        $descriptorspec = array( STDIN, STDOUT, STDERR );
+        $descriptorspec = [STDIN, STDOUT, STDERR];
         $command = sprintf('%s %s', $editor, escapeshellarg($filename));
 
         $output->writeln(sprintf('<info>Executing "%s"</info>', $command));

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EditCommand extends Command
+{
+    private const DESCRIPTION = 'Edit the latest changelog entry using the system editor.';
+
+    private const HELP = <<< 'EOH'
+Edit the latest changelog entry using the system editor ($EDITOR), or the
+editor provided via --editor.
+
+By default, the command will edit CHANGELOG.md in the current directory, unless
+a different file is specified via the --file option.
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+        $this->addOption(
+            'editor',
+            '-e',
+            InputOption::VALUE_REQUIRED,
+            'Alternate editor command to use to edit the changelog.'
+        );
+        $this->addOption(
+            'file',
+            '-f',
+            InputOption::VALUE_REQUIRED,
+            'Alternate changelog file to edit.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $editor = $input->getOption('editor') ?: null;
+        $changelogFile = $input->getOption('file') ?: realpath(getcwd()) . '/CHANGELOG.md';
+
+        if (! (new Edit())($output, $changelogFile, $editor)) {
+            $output->writeln(sprintf(
+                '<error>Could not edit %s; please check the output for details.</error>',
+                $changelogFile
+            ));
+            return 1;
+        }
+
+        $output->writeln(sprintf(
+            '<success>Edited most recent changelog in %s</success>',
+            $changelogFile
+        ));
+
+        return 0;
+    }
+}

--- a/test/EditTest.php
+++ b/test/EditTest.php
@@ -135,7 +135,7 @@ EOH;
 EOH;
         $tempFile = tempnam(sys_get_temp_dir(), 'CAK');
         file_put_contents($tempFile, $expectedContents);
-        
+
         $edit = new Edit();
         $updateChangelogEntry = $this->reflectMethod($edit, 'updateChangelogEntry');
         $updateChangelogEntry->invoke($edit, $this->tempFile, $tempFile, 4, 22);

--- a/test/EditTest.php
+++ b/test/EditTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog;
+
+use Phly\KeepAChangelog\Edit;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Throwable;
+
+class EditTest extends TestCase
+{
+    private $tempFile;
+
+    public function tearDown()
+    {
+        if ($this->tempFile && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+    }
+
+    public function reflectMethod(Edit $command, string $method) : ReflectionMethod
+    {
+        $r = new ReflectionMethod($command, $method);
+        $r->setAccessible(true);
+        return $r;
+    }
+
+    public function getSampleContents() : string
+    {
+        return <<< 'EOH'
+## 2.0.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+
+EOH;
+    }
+
+    public function testGetChangelogEntryReturnsNullIfNoChangelogEntryFound()
+    {
+        $edit = new Edit();
+        $getChangelogEntry = $this->reflectMethod($edit, 'getChangelogEntry');
+        $this->assertNull($getChangelogEntry->invoke($edit, __DIR__ . '/_files/invalid-composer/composer.json'));
+    }
+
+    public function testGetChangelogEntryReturnsExpectedDataWhenChangelogIsDiscovered()
+    {
+        $expected = $this->getSampleContents();
+        $edit = new Edit();
+        $getChangelogEntry = $this->reflectMethod($edit, 'getChangelogEntry');
+        $data = $getChangelogEntry->invoke($edit, __DIR__ . '/_files/CHANGELOG.md');
+
+        $this->assertEquals(4, $data->index);
+        $this->assertEquals(22, $data->length);
+        $this->assertEquals($expected, $data->contents);
+    }
+
+    public function testUsesSystemEditorIfPresentInEnv()
+    {
+        if (! getenv('EDITOR')) {
+            putenv('EDITOR=system-editor');
+        }
+
+        $edit = new Edit();
+        $discoverEditor = $this->reflectMethod($edit, 'discoverEditor');
+        $this->assertSame(getenv('EDITOR'), $discoverEditor->invoke($edit));
+    }
+
+    public function testUsesDefaultKnownEditorIfNoEditorPresentInEnv()
+    {
+        if (getenv('EDITOR')) {
+            putenv('EDITOR');
+        }
+
+        $edit = new Edit();
+        $discoverEditor = $this->reflectMethod($edit, 'discoverEditor');
+        $editor = $discoverEditor->invoke($edit);
+        $this->assertTrue(in_array($editor, ['notepad', 'vi'], true));
+    }
+
+    public function testUpdateChangelogEntryReplacesExistingContents()
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'KAC');
+        file_put_contents($this->tempFile, file_get_contents(__DIR__ . '/_files/CHANGELOG.md'));
+
+        $expectedContents = <<< 'EOH'
+## 2.0.0 - 2018-04-14
+
+### Added
+
+- Everything that needed adding.
+
+### Changed
+
+- Only what we have the wisdom to.
+
+### Deprecated
+
+- Those things we do not need anymore.
+
+### Removed
+
+- The things we previously decided we didn't need.
+
+### Fixed
+
+- The problems.
+
+
+EOH;
+        $tempFile = tempnam(sys_get_temp_dir(), 'CAK');
+        file_put_contents($tempFile, $expectedContents);
+        
+        $edit = new Edit();
+        $updateChangelogEntry = $this->reflectMethod($edit, 'updateChangelogEntry');
+        $updateChangelogEntry->invoke($edit, $this->tempFile, $tempFile, 4, 22);
+
+        $this->assertFileEquals(__DIR__ . '/_files/CHANGELOG-EDIT-EXPECTED.md', $this->tempFile);
+    }
+}

--- a/test/_files/CHANGELOG-EDIT-EXPECTED.md
+++ b/test/_files/CHANGELOG-EDIT-EXPECTED.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 2.0.0 - 2018-04-14
+
+### Added
+
+- Everything that needed adding.
+
+### Changed
+
+- Only what we have the wisdom to.
+
+### Deprecated
+
+- Those things we do not need anymore.
+
+### Removed
+
+- The things we previously decided we didn't need.
+
+### Fixed
+
+- The problems.
+
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.


### PR DESCRIPTION
Syntax:

```bash
$ keep-a-changelog edit [--editor|-e=] [--file|-f=]
```

Opens the most current changelog entry in the system editor (unless the `--editor` option is provided). By default, edits `CHANGELOG.md`, unless the `--file` option is provided.