### PR TITLE
Adds bump:to-version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Currently supported commands include:
 - `bump:major` will prepend a new changelog entry for a new major
   release, based on the latest release found in the `CHANGELOG.md` file.
 
+- `bump:to-version` will prepend a new changelog entry, using the version
+  specified on the command line.
+
 - `entry:added` will add a new changelog entry to the Added section of the
   current changelog within the `CHANGELOG.md` file.
 

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -33,6 +33,7 @@ $application->addCommands([
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump:bugfix'),
     new BumpCommand(BumpCommand::BUMP_MINOR, 'bump:minor'),
     new BumpCommand(BumpCommand::BUMP_MAJOR, 'bump:major'),
+    new BumpToVersionCommand('bump:to-version'),
     new EditCommand('edit'),
     new EntryCommand('entry:added'),
     new EntryCommand('entry:changed'),

--- a/src/BumpToVersionCommand.php
+++ b/src/BumpToVersionCommand.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Add a new changelog entry using the version specified.
+ */
+class BumpToVersionCommand extends Command
+{
+    private const DESCRIPTION = 'Create a new changelog entry for the specified release version.';
+
+    private const HELP = <<< 'EOH'
+Add a new release entry to the changelog, based on the latest release specified.
+
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'Version to use with newly created changelog entry.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $cwd = realpath(getcwd());
+
+        $changelogFile = sprintf('%s/CHANGELOG.md', $cwd);
+        if (! is_readable($changelogFile)) {
+            throw Exception\ChangelogFileNotFoundException::at($changelogFile);
+        }
+
+        $version = $input->getArgument('version');
+
+        $bumper = new ChangelogBump($changelogFile);
+        $bumper->updateChangelog($version);
+
+        $output->writeln(sprintf(
+            '<info>Added changelog entry for version %s</info>',
+            $version
+        ));
+
+        return 0;
+    }
+}

--- a/src/ChangelogBump.php
+++ b/src/ChangelogBump.php
@@ -15,6 +15,34 @@ class ChangelogBump
     private const CHANGELOG_LINE_REGEX = '/^\#\# (?<version>\d+\.\d+\.\d+(?:(?:alpha|beta|rc|dev|a|b)\d+)?) - (?:TBD|\d{4}-\d{2}-\d{2})$/m';
     // @codingStandardsIgnoreEnd
 
+    private const TEMPLATE = <<< 'EOT'
+
+
+## %s - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+
+EOT;
+
     /** @var string */
     private $changelogFile;
 
@@ -68,13 +96,7 @@ class ChangelogBump
      */
     public function updateChangelog(string $version)
     {
-        $changelog = sprintf("\n\n## %s - TBD\n\n", $version)
-            . "### Added\n\n- Nothing.\n\n"
-            . "### Changed\n\n- Nothing.\n\n"
-            . "### Deprecated\n\n- Nothing.\n\n"
-            . "### Removed\n\n- Nothing.\n\n"
-            . "### Fixed\n\n- Nothing.\n\n";
-
+        $changelog = sprintf(self::TEMPLATE, $version);
         $contents = file_get_contents($this->changelogFile);
         $contents = preg_replace(
             "/^(\# Changelog\n\n.*?)(\n\n\#\# )/s",


### PR DESCRIPTION
Syntax:

```bash
$ keep-a-changelog bump:to-version <version>
```

Adds a new entry to the changelog file using <version>.

Fixes #6