### PR TITLE
Adds global --file option

### DIFF
--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -12,6 +12,7 @@ namespace Phly\KeepAChangelog;
 
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
 
 // Setup/verify autoloading
 if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
@@ -28,6 +29,12 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
 $version = strstr(Versions::getVersion('phly/keep-a-changelog'), '@', true);
 
 $application = new Application('keep-a-changelog', $version);
+
+$application->getDefinition()
+    ->addOptions([
+        new InputOption('file', 'f', InputOption::VALUE_REQUIRED, 'The changelog file to create or modify'),
+    ]);
+
 $application->addCommands([
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump'),
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump:bugfix'),

--- a/src/BumpCommand.php
+++ b/src/BumpCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class BumpCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     public const BUMP_BUGFIX = 'bugfix';
     public const BUMP_MAJOR = 'major';
     public const BUMP_MINOR = 'minor';
@@ -71,9 +73,7 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $cwd = realpath(getcwd());
-
-        $changelogFile = sprintf('%s/CHANGELOG.md', $cwd);
+        $changelogFile = $this->getChangelogFile($input);
         if (! is_readable($changelogFile)) {
             throw Exception\ChangelogFileNotFoundException::at($changelogFile);
         }

--- a/src/BumpToVersionCommand.php
+++ b/src/BumpToVersionCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class BumpToVersionCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const DESCRIPTION = 'Create a new changelog entry for the specified release version.';
 
     private const HELP = <<< 'EOH'
@@ -39,9 +41,7 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $cwd = realpath(getcwd());
-
-        $changelogFile = sprintf('%s/CHANGELOG.md', $cwd);
+        $changelogFile = $this->getChangelogFile($input);
         if (! is_readable($changelogFile)) {
             throw Exception\ChangelogFileNotFoundException::at($changelogFile);
         }

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EditCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const DESCRIPTION = 'Edit the latest changelog entry using the system editor.';
 
     private const HELP = <<< 'EOH'
@@ -36,18 +38,12 @@ EOH;
             InputOption::VALUE_REQUIRED,
             'Alternate editor command to use to edit the changelog.'
         );
-        $this->addOption(
-            'file',
-            '-f',
-            InputOption::VALUE_REQUIRED,
-            'Alternate changelog file to edit.'
-        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $editor = $input->getOption('editor') ?: null;
-        $changelogFile = $input->getOption('file') ?: realpath(getcwd()) . '/CHANGELOG.md';
+        $changelogFile = $this->getChangelogFile($input);
 
         if (! (new Edit())($output, $changelogFile, $editor)) {
             $output->writeln(sprintf(

--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EntryCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const DESC_TEMPLATE = 'Create a new changelog entry for the latest changelog in the "%s" section';
 
     private const HELP_TEMPLATE = <<< 'EOH'
@@ -81,12 +83,12 @@ EOH;
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $output->writeln(sprintf(
-            '<info>Preparing entry fro %s section</info>',
+            '<info>Preparing entry for %s section</info>',
             ucwords($this->type)
         ));
 
         $entry = $this->prepareEntry($input);
-        $changelog = sprintf('%s/CHANGELOG.md', realpath(getcwd()));
+        $changelog = $this->getChangelogFile($input);
 
         $output->writeln(sprintf(
             '<info>Writing "%s" entry to %s</info>',

--- a/src/GetChangelogFileTrait.php
+++ b/src/GetChangelogFileTrait.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Compose this trait for any command that needs access to the changelog file.
+ */
+trait GetChangelogFileTrait
+{
+    private function getChangelogFile(InputInterface $input) : string
+    {
+        return $input->getOption('file') ?: realpath(getcwd()) . '/CHANGELOG.md';
+    }
+}

--- a/src/NewChangelogCommand.php
+++ b/src/NewChangelogCommand.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NewChangelogCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const DESCRIPTION = 'Create a new changelog file.';
 
     private const HELP = <<< 'EOH'
@@ -29,12 +31,6 @@ EOH;
         $this->setDescription(self::DESCRIPTION);
         $this->setHelp(self::HELP);
         $this->addOption(
-            'file',
-            '-f',
-            InputOption::VALUE_REQUIRED,
-            'Changelog file to create; if not provided, defaults to CHANGELOG.md.'
-        );
-        $this->addOption(
             'initial-version',
             '-i',
             InputOption::VALUE_REQUIRED,
@@ -44,7 +40,7 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $file = $input->getOption('file') ?: realpath(getcwd()) . '/CHANGELOG.md';
+        $file = $this->getChangelogFile($input);
         $version = $input->getOption('initial-version') ?: '0.1.0';
 
         (new NewChangelog())($file, $version);

--- a/src/ReadyCommand.php
+++ b/src/ReadyCommand.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ReadyCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const DESCRIPTION = 'In the latest changelog entry, mark the entry ready by setting its release date.';
 
     private const HELP = <<< 'EOH'
@@ -46,7 +48,7 @@ EOH;
             $date
         ));
 
-        $changelogFile = sprintf('%s/CHANGELOG.md', realpath(getcwd()));
+        $changelogFile = $this->getChangelogFile($input);
 
         (new SetDate())($changelogFile, $date);
 

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ReleaseCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const HELP = <<< 'EOH'
 Create a github release using the changelog entry for the specified version.
 
@@ -100,7 +102,7 @@ EOH;
             return 1;
         }
 
-        $changelogFile = sprintf('%s/CHANGELOG.md', $cwd);
+        $changelogFile = $this->getChangelogFile($input);
         if (! is_readable($changelogFile)) {
             throw Exception\ChangelogFileNotFoundException::at($changelogFile);
         }

--- a/src/TaggerCommand.php
+++ b/src/TaggerCommand.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TaggerCommand extends Command
 {
+    use GetChangelogFileTrait;
+
     private const HELP = <<< 'EOH'
 Create a new git tag for the current repository, using the relevant changelog entry.
 
@@ -65,7 +67,7 @@ EOH;
         $package = $input->getOption('package') ?: basename($cwd);
         $tagName = $input->getOption('tagname') ?: $version;
 
-        $changelogFile = sprintf('%s/CHANGELOG.md', $cwd);
+        $changelogFile = $this->getChangelogFile($input);
         if (! is_readable($changelogFile)) {
             throw Exception\ChangelogFileNotFoundException::at($changelogFile);
         }


### PR DESCRIPTION
The global option `--file` (or `-f`) may now be used with any command to specify a different changelog file in which to perform the operation.

Fixes #13