### PR TITLE
Update instructions for global composer bin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,16 @@ Alternately, install globally, for use with any repository:
 $ composer global require phly/keep-a-changelog
 ```
 
-If you install globally, ensure you add `$HOME/.composer/bin` to your `$PATH`
-environment variable. Once setup this way, you can call `keep-a-changelog`
-instead of `./vendor/bin/keep-a-changelog`.
+If you install globally, ensure you add global composer vendor binaries
+directory to your `$PATH` environment variable. You can get its location with
+following command:
+
+```bash
+$ composer global config bin-dir --absolute
+```
+
+Once setup this way, you can call `keep-a-changelog` instead of
+`./vendor/bin/keep-a-changelog`.
 
 ## Usage
 


### PR DESCRIPTION
Global bin directory location might differ depending on several conditions. Composer follows XDG specifications by default, but it would use `$HOME/.composer` if it is present and `$HOME/.config/composer` is not.
Composer provides a reliable way to get bin dir location: `composer global config bin-dir --absolute`

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
