### PR TITLE
Fix option mismatch for overwrite option

### DIFF
--- a/src/NewChangelogCommand.php
+++ b/src/NewChangelogCommand.php
@@ -49,9 +49,9 @@ EOH;
     {
         $file = $this->getChangelogFile($input);
         $version = $input->getOption('initial-version') ?: '0.1.0';
-        $override = $input->getOption('override') ?: false;
+        $overwrite = $input->getOption('overwrite') ?: false;
 
-        if (file_exists($file) && ! $override) {
+        if (file_exists($file) && ! $overwrite) {
             throw Exception\ChangelogExistsException::forFile($file);
         }
 


### PR DESCRIPTION
The latest change only changed the definition of the "override" option to "overwrite", but not the actual usage, which results in an error when calling the new command.