### PR TITLE
Check github URLs for existing pull request links

### DIFF
--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -134,16 +134,94 @@ EOH;
 
     private function preparePullRequestLink(int $pr, ?string $package) : string
     {
-        $package = $package ?: (new ComposerPackage())->getName(realpath(getcwd()));
+        if (null !== $package) {
+            $link = $this->generatePullRequestLink($pr, $package);
 
+            if (null !== $link) {
+                return $link;
+            }
+
+            throw Exception\InvalidPullRequestLinkException::forLink($link);
+        }
+
+        $link = $this->generatePullRequestLink($pr, (new ComposerPackage())->getName(realpath(getcwd())));
+
+        if (null !== $link) {
+            return $link;
+        }
+
+        foreach ($this->getGithubPackageNames() as $package) {
+            $link = $this->generatePullRequestLink($pr, $package);
+
+            if (null !== $link) {
+                return $link;
+            }
+        }
+
+        throw Exception\InvalidPullRequestLinkException::noValidLinks($pr);
+    }
+
+    private function getGithubPackageNames() : array
+    {
+        exec('git remote', $remotes, $return);
+
+        if (0 !== $return) {
+            return [];
+        }
+
+        $packages = [];
+
+        foreach ($remotes as $remote) {
+            $url = [];
+            exec(sprintf('git remote get-url %s', escapeshellarg($remote)), $url, $return);
+
+            if (0 !== $return) {
+                continue;
+            }
+
+            if (0 === preg_match('(github.com[:/](.*?)\.git)', $url[0], $matches)) {
+                continue;
+            }
+
+            $packages[] = $matches[1];
+        }
+
+        return $packages;
+    }
+
+    private function generatePullRequestLink(int $pr, string $package) : ?string
+    {
         if (! preg_match('#^[a-z0-9]+[a-z0-9_-]*/[a-z0-9]+[a-z0-9_-]*$#i', $package)) {
             throw Exception\InvalidPackageNameException::forPackage($package);
         }
 
-        return sprintf(
+        $link = sprintf(
             'https://github.com/%s/pull/%d',
             $package,
             $pr
         );
+
+        if (! $this->probeLink($link)) {
+            return null;
+        }
+
+        return $link;
+    }
+
+    private function probeLink(string $link) : bool
+    {
+        $headers = get_headers($link, 1, stream_context_create(['http' => ['method'=>'HEAD']]));
+        $statusLine = explode(' ', $headers[0]);
+        $statusCode = (int) $statusLine[1];
+
+        if ($statusCode < 300) {
+            return true;
+        }
+
+        if ($statusCode >= 300 && $statusCode <= 399 && array_key_exists('Location', $headers)) {
+            return $this->probeLink($headers['Location']);
+        }
+
+        return false;
     }
 }

--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -141,7 +141,7 @@ EOH;
                 return $link;
             }
 
-            throw Exception\InvalidPullRequestLinkException::forLink($link);
+            throw Exception\InvalidPullRequestLinkException::forPackage($package, $pr);
         }
 
         $link = $this->generatePullRequestLink($pr, (new ComposerPackage())->getName(realpath(getcwd())));
@@ -210,7 +210,7 @@ EOH;
 
     private function probeLink(string $link) : bool
     {
-        $headers = get_headers($link, 1, stream_context_create(['http' => ['method'=>'HEAD']]));
+        $headers = get_headers($link, 1, stream_context_create(['http' => ['method' => 'HEAD']]));
         $statusLine = explode(' ', $headers[0]);
         $statusCode = (int) $statusLine[1];
 

--- a/src/Exception/InvalidPullRequestException.php
+++ b/src/Exception/InvalidPullRequestException.php
@@ -11,21 +11,12 @@ namespace Phly\KeepAChangelog\Exception;
 
 use RuntimeException;
 
-class InvalidPullRequestLinkException extends RuntimeException
+class InvalidPullRequestException extends RuntimeException
 {
-    public static function forPackage(string $package, int $pr) : self
+    public static function for(int $pr) : self
     {
         return new self(sprintf(
-            'The pull request package %s has no PR %d',
-            $package,
-            $pr
-        ));
-    }
-
-    public static function noValidLinks(int $pr) : self
-    {
-        return new self(sprintf(
-            'No valid pull request link could be found for PR %d',
+            'PR %d is not valid',
             $pr
         ));
     }

--- a/src/Exception/InvalidPullRequestLinkException.php
+++ b/src/Exception/InvalidPullRequestLinkException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog-tagger for the canonical source repository
+ * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog-tagger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Exception;
+
+use RuntimeException;
+
+class InvalidPullRequestLinkException extends RuntimeException
+{
+    public static function forLink(string $link) : self
+    {
+        return new self(sprintf(
+            'The pull request link %s does not exist',
+            $link
+        ));
+    }
+
+    public static function noValidLinks(int $pr) : self
+    {
+        return new self(sprintf(
+            'No valid pull request link could be found for PR %d',
+            $pr
+        ));
+    }
+}

--- a/test/EntryCommandTest.php
+++ b/test/EntryCommandTest.php
@@ -86,7 +86,7 @@ class EntryCommandTest extends TestCase
     public function testPrepareEntryWithPrOptionRaisesExceptionIfPackageOptionIsInvalid()
     {
         $entry = 'This is the entry';
-        $pr = 42;
+        $pr = 1;
         $package = 'not-a-valid-package-name';
 
         $this->input->getArgument('entry')->willReturn($entry);
@@ -99,10 +99,10 @@ class EntryCommandTest extends TestCase
         $this->reflectMethod($command, 'prepareEntry')->invoke($command, $this->input->reveal());
     }
 
-    public function testPrepareEntryReturnsEntryWithPrLinkPrefixedWhenPackageOptionPresentAndValid()
+    public function testPrepareEntryWithPrOptionRaisesExceptionIfLinkIsInvalid()
     {
         $entry = 'This is the entry';
-        $pr = 42;
+        $pr = 9999999999;
         $package = 'phly/keep-a-changelog';
 
         $this->input->getArgument('entry')->willReturn($entry);
@@ -111,7 +111,23 @@ class EntryCommandTest extends TestCase
 
         $command = new EntryCommand('entry:added');
 
-        $expected = '[#42](https://github.com/phly/keep-a-changelog/pull/42) ' . $entry;
+        $this->expectException(Exception\InvalidPullRequestLinkException::class);
+        $this->reflectMethod($command, 'prepareEntry')->invoke($command, $this->input->reveal());
+    }
+
+    public function testPrepareEntryReturnsEntryWithPrLinkPrefixedWhenPackageOptionPresentAndValid()
+    {
+        $entry = 'This is the entry';
+        $pr = 1;
+        $package = 'phly/keep-a-changelog';
+
+        $this->input->getArgument('entry')->willReturn($entry);
+        $this->input->getOption('pr')->willReturn($pr);
+        $this->input->getOption('package')->willReturn($package);
+
+        $command = new EntryCommand('entry:added');
+
+        $expected = '[#1](https://github.com/phly/keep-a-changelog/pull/1) ' . $entry;
 
         $this->assertSame(
             $expected,


### PR DESCRIPTION
This PR introduces actual checking of generated pull request links for their existence. If it encounters a redirect, it will probe the given Location as well.

This PR follows the original behaviour of first checking a possibly provided package name. If a PR with that package name does not exist, the script bails out immediately. Next it will probe a link generated from the composer package name. If that one fails as well, it will resort to trying out all remote URLs supplied by git. If everything fails, an exception will be thrown.