### PR TITLE
Ensure EntryCommand works!

### DIFF
--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -86,6 +86,12 @@ EOH;
             InputOption::VALUE_OPTIONAL,
             'Repository provider. Options: github or gitlab; defaults to github'
         );
+        $this->addOption(
+            'global',
+            'g',
+            InputOption::VALUE_NONE,
+            'Use the global config file'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) : int

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -31,7 +31,7 @@ trait GetConfigValuesTrait
     ) : Config {
         $config = $this->getConfig($input);
 
-        $token  = $input->getOption($tokenOptionName);
+        $token  = $input->hasOption($tokenOptionName) ? $input->getOption($tokenOptionName) : null;
         $config = $token ? $config->withToken($token) : $config;
 
         $provider = $input->getOption($providerOptionName);

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -38,9 +38,10 @@ tagname if provided (as tags and release versions may differ; e.g.,
 It then attempts to create a release on the specified provider, using the provided 
 package name and version. To do this, the tool requires that you have created and 
 registered a personal access token in the provider. The tool will look in 
-$HOME/.keep-a-changelog/token for the value unless one is provided via the --token option. 
-When a token is provided via the --token option, the tool will prompt you to ask if you
-wish to store the token in that location for later use.
+$HOME/.keep-a-changelog/config.ini or $HOME/.keep-a-changelog/token for the
+value unless one is provided via the --token option.  When a token is provided
+via the --token option, the tool will prompt you to ask if you wish to store
+the token for later use.
 
 When complete, the tool will provide a URL to the created release.
 

--- a/test/EntryCommandTest.php
+++ b/test/EntryCommandTest.php
@@ -99,7 +99,8 @@ class EntryCommandTest extends TestCase
         $this->input->getOption('pr')->willReturn($pr);
         $this->input->getOption('package')->willReturn($package);
         $this->input->getOption('global')->willReturn(null);
-        $this->input->getOption('token')->willReturn(null);
+        $this->input->hasOption('token')->willReturn(false);
+        $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
 
         $command = new EntryCommand('entry:added');
@@ -120,7 +121,8 @@ class EntryCommandTest extends TestCase
         $this->input->getOption('pr')->willReturn($pr);
         $this->input->getOption('package')->willReturn($package);
         $this->input->getOption('global')->willReturn(null);
-        $this->input->getOption('token')->willReturn(null);
+        $this->input->hasOption('token')->willReturn(false);
+        $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
 
         $command = new EntryCommand('entry:added');
@@ -141,7 +143,8 @@ class EntryCommandTest extends TestCase
         $this->input->getOption('pr')->willReturn($pr);
         $this->input->getOption('package')->willReturn($package);
         $this->input->getOption('global')->willReturn(null);
-        $this->input->getOption('token')->willReturn(null);
+        $this->input->hasOption('token')->willReturn(false);
+        $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
 
         $command = new EntryCommand('entry:added');
@@ -166,7 +169,8 @@ class EntryCommandTest extends TestCase
         $this->input->getOption('pr')->willReturn($pr);
         $this->input->getOption('package')->willReturn($package);
         $this->input->getOption('global')->willReturn(null);
-        $this->input->getOption('token')->willReturn(null);
+        $this->input->hasOption('token')->willReturn(false);
+        $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
 
         $command = new EntryCommand('entry:added');


### PR DESCRIPTION
After the previous round of changes, the `EntryCommand` would raise errors due to attempting to retrieve the `global` and `token` options, which were not defined in the command.

The `token` option is unneeded, so this patch changes `GetConfigValuesTrait` to test if the token option is present before trying to retrieve it.

The `global` option is still relevant, however, as it details where to get the `provider` from. This option was added to the `EntryCommand`.