### PR TITLE
Fixes a missing argument error

### DIFF
--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -106,7 +106,7 @@ EOH;
 
         $this->verifyTagExists($tagName);
 
-        $config  = $this->prepareConfig();
+        $config  = $this->prepareConfig($input);
         $package = $input->getArgument('package');
 
         $token = $this->getToken($input, $output, $config);


### PR DESCRIPTION
ReleaseCommand was not passing the `$input` to `prepareConfig()`, leading to a fatal error.