### PR TITLE
Fix argument order when calling `getToken()` within `ReleaseCommand`

### DIFF
--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -109,7 +109,7 @@ EOH;
         $config  = $this->prepareConfig($input);
         $package = $input->getArgument('package');
 
-        $token = $this->getToken($input, $output, $config);
+        $token = $this->getToken($config, $input, $output);
         if (! $token) {
             return 1;
         }


### PR DESCRIPTION
`ReleaseCommand` was calling `getToken()` with the arguments in the incorrect order, causing a fatal error.