### PR TITLE
allow to use with symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "m4tthumphrey/php-gitlab-api": "^9.9",
         "ocramius/package-versions": "^1.3",
         "php-http/guzzle6-adapter": "^1.1",
-        "symfony/console": "^4.0"
+        "symfony/console": "^3.4|^4.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6d1f07c9e0eb2fc8b84540cf8e3dc46",
+    "content-hash": "465da80edeb2545cad6c1e70885dec09",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -308,16 +308,16 @@
         },
         {
             "name": "m4tthumphrey/php-gitlab-api",
-            "version": "9.10.0",
+            "version": "9.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/m4tthumphrey/php-gitlab-api.git",
-                "reference": "c946569ae75eff6317a5691ab590b6eb071bdb26"
+                "reference": "3c7f6f6f7c2c561fff6d94d2ffb120289fa8f825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/m4tthumphrey/php-gitlab-api/zipball/c946569ae75eff6317a5691ab590b6eb071bdb26",
-                "reference": "c946569ae75eff6317a5691ab590b6eb071bdb26",
+                "url": "https://api.github.com/repos/m4tthumphrey/php-gitlab-api/zipball/3c7f6f6f7c2c561fff6d94d2ffb120289fa8f825",
+                "reference": "3c7f6f6f7c2c561fff6d94d2ffb120289fa8f825",
                 "shasum": ""
             },
             "require": {
@@ -334,7 +334,7 @@
                 "guzzlehttp/psr7": "^1.2",
                 "php-http/guzzle6-adapter": "^1.0",
                 "php-http/mock-client": "^1.0",
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -372,7 +372,7 @@
                 "api",
                 "gitlab"
             ],
-            "time": "2018-06-15T13:59:39+00:00"
+            "time": "2018-11-16T21:05:00+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -1945,16 +1945,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.4.3",
+            "version": "7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c151651fb6ed264038d486ea262e243af72e5e64"
+                "reference": "b1be2c8530c4c29c3519a052c9fb6cee55053bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c151651fb6ed264038d486ea262e243af72e5e64",
-                "reference": "c151651fb6ed264038d486ea262e243af72e5e64",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b1be2c8530c4c29c3519a052c9fb6cee55053bbd",
+                "reference": "b1be2c8530c4c29c3519a052c9fb6cee55053bbd",
                 "shasum": ""
             },
             "require": {
@@ -2025,7 +2025,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-23T05:57:41+00:00"
+            "time": "2018-11-14T16:52:02+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2592,16 +2592,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -2666,7 +2666,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
as symfony 3.4 is compatible with symfony 4, the hard requirement for symfony 4 is not necessary.
```
        "symfony/console": "^4.0"
```
->
```
        "symfony/console": "^3.4|^4.0"
```