### PR TITLE
Expand changelog editing capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.1
       env:
         - DEPS=latest
@@ -30,7 +28,18 @@ matrix:
     - php: 7.2
       env:
         - DEPS=locked
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 7.2
+      env:
+        - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
       env:
         - DEPS=latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,26 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) adds the command `version:list`, which will list all versions and
+  associated release dates from the changelog file.
+
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) adds the command `version:remove <version>`, which will remove the
+  changelog entry for the provided version, if it exists.
+
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) adds the command `version:show <version>`, which will show the full
+  release entry in the changelog for the provided version, along with its
+  release date.
 
 ### Changed
 
-- Nothing.
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) aliases the `edit` command to `version:edit`.
+
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) adds an optional `<version>` argument to the `version:edit` command,
+  allowing users to edit a specific release version entry.
 
 ### Deprecated
 
-- Nothing.
+- [#41](https://github.com/phly/keep-a-changelog/pull/41) deprecates the `edit` command in favor of `version:edit`.
 
 ### Removed
 
@@ -297,28 +308,6 @@ All notable changes to this project will be documented in this file, in reverse 
 - Adds a new command, "ready", which will set the date for the first
   un-dated changelog entry in the CHANGELOG.md. You may also pass the --date or -d option
   to specify an alternate date, or to use a date formate other than YYYY-MM-DD.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
-## 1.1.3 - TBD
-
-### Added
-
-- Nothing.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The available providers are:
 
 Currently supported commands include:
 
+- `new` will create a new changelog file for you; specify `--initial-version` or
+  `-i` if you want to start with a version other than 0.1.0; use `--file` or
+  `-f` to specify a file other than `CHANGELOG.md`.
+
 - `config` will create a config file after prompting you for the preferred
   provider and its associated token. By default, the file is stored locally as
   `.keep-a-changelog.ini`; if the `--global` (or `-g`) option is provided, the
@@ -94,8 +98,16 @@ Currently supported commands include:
 - `entry:fixed` will add a new changelog entry to the Fixed section of the
   current changelog within the `CHANGELOG.md` file.
 
-- `edit` will open the most recent changelog section in the system editor
-  to allow editing the full entry at once.
+- `version:edit` will open the most recent changelog section in the system editor
+  to allow editing the full entry at once. If you provide a `<version>`
+  argument, it will edit that specific version.
+
+- `version:list` will list all versions in the changelog, along with associated
+  release dates.
+
+- `version:remove` will remove the given version's entry from the changelog.
+
+- `version:show` will show the entry associated with the given version.
 
 For a list of required parameters and all options for a command, run:
 

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -51,6 +51,7 @@ $application->addCommands([
     new NewChangelogCommand('new'),
     new ReadyCommand('ready'),
     new ReleaseCommand('release'),
+    new ShowVersionCommand('show-version'),
     new TaggerCommand('tag'),
 ]);
 $application->run();

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -48,6 +48,7 @@ $application->addCommands([
     new EntryCommand('entry:deprecated'),
     new EntryCommand('entry:removed'),
     new EntryCommand('entry:fixed'),
+    new ListVersionsCommand('list-versions'),
     new NewChangelogCommand('new'),
     new ReadyCommand('ready'),
     new ReleaseCommand('release'),

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -2,7 +2,7 @@
 <?php
 /**
  * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
- * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @copyright Copyright (c) 2018-2019 Matthew Weier O'Phinney
  * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
  */
 
@@ -42,18 +42,19 @@ $application->addCommands([
     new BumpCommand(BumpCommand::BUMP_MAJOR, 'bump:major'),
     new BumpToVersionCommand('bump:to-version'),
     new ConfigCommand('config'),
-    new EditCommand('edit'),
+    new EditCommand('edit', $deprecated = true),
+    new EditCommand('version:edit'),
     new EntryCommand('entry:added'),
     new EntryCommand('entry:changed'),
     new EntryCommand('entry:deprecated'),
     new EntryCommand('entry:removed'),
     new EntryCommand('entry:fixed'),
-    new ListVersionsCommand('list-versions'),
+    new ListVersionsCommand('version:list'),
     new NewChangelogCommand('new'),
     new ReadyCommand('ready'),
     new ReleaseCommand('release'),
-    new RemoveCommand('remove'),
-    new ShowVersionCommand('show-version'),
+    new RemoveCommand('version:remove'),
+    new ShowVersionCommand('version:show'),
     new TaggerCommand('tag'),
 ]);
 $application->run();

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -51,6 +51,7 @@ $application->addCommands([
     new NewChangelogCommand('new'),
     new ReadyCommand('ready'),
     new ReleaseCommand('release'),
+    new RemoveCommand('remove'),
     new ShowVersionCommand('show-version'),
     new TaggerCommand('tag'),
 ]);

--- a/src/ChangelogEditor.php
+++ b/src/ChangelogEditor.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use stdClass;
+
+trait ChangelogEditor
+{
+    /**
+     * Retrieves changelog entry from the file.
+     *
+     * If $version is null, it fetches the first entry; otherwise, it attempts
+     * to fetch the entry associated with the given version.
+     *
+     * If no changelog entry is found, returns null. Otherwise, returns an
+     * anonymous object with the keys:
+     *
+     * - index, indicating the line number where the contents began
+     * - length, the number of lines in the contents
+     * - contents, a string representing the changelog entry found in its entierty
+     */
+    private function getChangelogEntry($filename, ?string $version = null) : ?stdClass
+    {
+        $contents = file($filename);
+        if (false === $contents) {
+            throw Exception\ChangelogFileNotFoundException::at($filename);
+        }
+
+        $data = (object) [
+            'contents' => '',
+            'index' => null,
+            'length' => 0,
+        ];
+
+        $boundaryRegex = '/^## \d+\.\d+\.\d+/';
+
+        $regex = $version
+            ? sprintf('/^## %s/', preg_quote($version))
+            : $boundaryRegex;
+
+        foreach ($contents as $index => $line) {
+            if ($data->index && preg_match($boundaryRegex, $line)) {
+                break;
+            }
+
+            if (preg_match($regex, $line)) {
+                $data->contents = $line;
+                $data->index = $index;
+                $data->length = 1;
+                continue;
+            }
+
+            if (! $data->index) {
+                continue;
+            }
+
+            $data->contents .= $line;
+            $data->length += 1;
+        }
+
+        return $data->index !== null ? $data : null;
+    }
+
+    private function updateChangelogEntry(string $filename, string $replacement, int $index, int $length)
+    {
+        $contents = file($filename);
+        array_splice($contents, $index, $length, $replacement);
+        file_put_contents($filename, implode('', $contents));
+    }
+}

--- a/src/ChangelogParser.php
+++ b/src/ChangelogParser.php
@@ -11,6 +11,36 @@ namespace Phly\KeepAChangelog;
 
 class ChangelogParser
 {
+    /**
+     * @param  string $changelogFile Changelog file to parse for versions.
+     * @return iterable<string, string> where keys are the version entries,
+     *     and values are the associated dates (either Y-m-d format, or the
+     *     string 'TBD')
+     */
+    public function findAllVersions(string $changelogFile) : iterable
+    {
+        $fh = fopen($changelogFile, 'r');
+        $regex = sprintf(
+            '/^%s %s - %s$/i',
+            preg_quote('##'),
+            '(?P<version>\d+\.\d+\.\d+(?:(?:alpha|a|beta|b|rc|dev)\d+)?)',
+            '(?P<date>(\d{4}-\d{2}-\d{2}|TBD))'
+        );
+
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if (! $line) {
+                continue;
+            }
+
+            if (preg_match($regex, $line, $matches)) {
+                yield $matches['version'] => $matches['date'];
+            }
+        }
+
+        fclose($fh);
+    }
+
     public function findReleaseDateForVersion(string $changelog, string $version) : string
     {
         $regex = preg_quote('## ' . $version);

--- a/src/ChangelogParser.php
+++ b/src/ChangelogParser.php
@@ -11,14 +11,29 @@ namespace Phly\KeepAChangelog;
 
 class ChangelogParser
 {
-    public function findChangelogForVersion(string $changelog, string $version)
+    public function findReleaseDateForVersion(string $changelog, string $version) : string
     {
         $regex = preg_quote('## ' . $version);
         if (! preg_match('/^' . $regex . '/m', $changelog)) {
             throw Exception\ChangelogNotFoundException::forVersion($version);
         }
 
-        $regex .= ' - \d{4}-\d{2}-\d{2}';
+        $regex .= ' - (?P<date>(\d{4}-\d{2}-\d{2}|TBD))';
+        if (! preg_match('/^' . $regex . '/m', $changelog, $matches)) {
+            throw Exception\ChangelogMissingDateException::forVersion($version);
+        }
+
+        return $matches['date'];
+    }
+
+    public function findChangelogForVersion(string $changelog, string $version) : string
+    {
+        $regex = preg_quote('## ' . $version);
+        if (! preg_match('/^' . $regex . '/m', $changelog)) {
+            throw Exception\ChangelogNotFoundException::forVersion($version);
+        }
+
+        $regex .= ' - (\d{4}-\d{2}-\d{2}|TBD)';
         if (! preg_match('/^' . $regex . '/m', $changelog)) {
             throw Exception\ChangelogMissingDateException::forVersion($version);
         }

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 
 namespace Phly\KeepAChangelog;
 
-use stdClass;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Edit
 {
+    use ChangelogEditor;
+
     public function __invoke(
         OutputInterface $output,
         string $filename,
@@ -29,7 +30,7 @@ class Edit
             return false;
         }
 
-        $editor = $editor ?: $this->discoverEditor();
+        $editor   = $editor ?: $this->discoverEditor();
         $tempFile = $this->createTempFileWithContents($changelogData->contents);
 
         $status = $this->spawnEditor($output, $editor, $tempFile);
@@ -42,64 +43,13 @@ class Edit
             return false;
         }
 
-
-        $this->updateChangelogEntry($filename, $tempFile, $changelogData->index, $changelogData->length);
+        $this->updateChangelogEntry(
+            $filename,
+            file_get_contents($tempFile),
+            $changelogData->index,
+            $changelogData->length
+        );
         return true;
-    }
-
-    /**
-     * Retrieves changelog entry from the file.
-     *
-     * If $version is null, it fetches the first entry; otherwise, it attempts
-     * to fetch the entry associated with the given version.
-     *
-     * If no changelog entry is found, returns null. Otherwise, returns an
-     * anonymous object with the keys:
-     *
-     * - index, indicating the line number where the contents began
-     * - length, the number of lines in the contents
-     * - contents, a string representing the changelog entry found in its entierty
-     */
-    private function getChangelogEntry($filename, ?string $version = null) : ?stdClass
-    {
-        $contents = file($filename);
-        if (false === $contents) {
-            throw Exception\ChangelogFileNotFoundException::at($filename);
-        }
-
-        $data = (object) [
-            'contents' => '',
-            'index' => null,
-            'length' => 0,
-        ];
-
-        $boundaryRegex = '/^## \d+\.\d+\.\d+/';
-
-        $regex = $version
-            ? sprintf('/^## %s/', preg_quote($version))
-            : $boundaryRegex;
-
-        foreach ($contents as $index => $line) {
-            if ($data->index && preg_match($boundaryRegex, $line)) {
-                break;
-            }
-
-            if (preg_match($regex, $line)) {
-                $data->contents = $line;
-                $data->index = $index;
-                $data->length = 1;
-                continue;
-            }
-
-            if (! $data->index) {
-                continue;
-            }
-
-            $data->contents .= $line;
-            $data->length += 1;
-        }
-
-        return $data->index !== null ? $data : null;
     }
 
     /**
@@ -146,13 +96,5 @@ class Edit
 
         $process = proc_open($command, $descriptorspec, $pipes);
         return proc_close($process);
-    }
-
-    private function updateChangelogEntry(string $filename, string $tempFile, int $index, int $length)
-    {
-        $contents = file($filename);
-        $replacement = file_get_contents($tempFile);
-        array_splice($contents, $index, $length, $replacement);
-        file_put_contents($filename, implode('', $contents));
     }
 }

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,6 +33,11 @@ EOH;
     {
         $this->setDescription(self::DESCRIPTION);
         $this->setHelp(self::HELP);
+        $this->addArgument(
+            'version',
+            InputArgument::OPTIONAL,
+            'A specific changelog version to edit.'
+        );
         $this->addOption(
             'editor',
             '-e',
@@ -42,10 +48,11 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $editor = $input->getOption('editor') ?: null;
+        $editor        = $input->getOption('editor') ?: null;
+        $version       = $input->getArgument('version') ?: null;
         $changelogFile = $this->getChangelogFile($input);
 
-        if (! (new Edit())($output, $changelogFile, $editor)) {
+        if (! (new Edit())($output, $changelogFile, $editor, $version)) {
             $output->writeln(sprintf(
                 '<error>Could not edit %s; please check the output for details.</error>',
                 $changelogFile
@@ -53,10 +60,10 @@ EOH;
             return 1;
         }
 
-        $output->writeln(sprintf(
-            '<info>Edited most recent changelog in %s</info>',
-            $changelogFile
-        ));
+        $message = $version
+            ? sprintf('<info>Edited change for version %s in %s</info>', $version, $changelogFile)
+            : sprintf('<info>Edited most recent changelog in %s</info>', $changelogFile);
+        $output->writeln($message);
 
         return 0;
     }

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -29,10 +29,27 @@ By default, the command will edit CHANGELOG.md in the current directory, unless
 a different file is specified via the --file option.
 EOH;
 
+    /** @var bool */
+    private $deprecated;
+
+    public function __construct(string $name = '', bool $deprecated = false)
+    {
+        $this->deprecated = $deprecated;
+        parent::__construct($name);
+    }
+
     protected function configure() : void
     {
-        $this->setDescription(self::DESCRIPTION);
-        $this->setHelp(self::HELP);
+        $description = $this->deprecated
+            ? sprintf('(DEPRECATED) %s', self::DESCRIPTION)
+            : self::DESCRIPTION;
+        $this->setDescription($description);
+
+        $help = $this->deprecated
+            ? sprintf("DEPRECATED; USE version:edit INSTEAD\n\n%s", self::HELP)
+            : self::HELP;
+        $this->setHelp($help);
+
         $this->addArgument(
             'version',
             InputArgument::OPTIONAL,
@@ -48,6 +65,10 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
+        if ($this->deprecated) {
+            $output->writeln('<error>WARNING! This command is deprecated; use version:edit instead!</error>');
+        }
+
         $editor        = $input->getOption('editor') ?: null;
         $version       = $input->getArgument('version') ?: null;
         $changelogFile = $this->getChangelogFile($input);

--- a/src/ListVersionsCommand.php
+++ b/src/ListVersionsCommand.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListVersionsCommand extends Command
+{
+    use GetChangelogFileTrait;
+
+    private const DESCRIPTION = 'List all versions represented in the changelog file.';
+
+    private const HELP = <<< 'EOH'
+Lists all versions represented in the changelog file, along with associated
+release dates.
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $changelogFile = $this->getChangelogFile($input);
+
+        $output->writeln('<info>Found the following versions:</info>');
+        foreach ((new ChangelogParser())->findAllVersions($changelogFile) as $version => $date) {
+            $output->writeln(sprintf('- %s (release date: %s)', $version, $date));
+        }
+
+        return 0;
+    }
+}

--- a/src/Remove.php
+++ b/src/Remove.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Remove
+{
+    use ChangelogEditor;
+
+    public function __invoke(OutputInterface $output, string $filename, string $version) : bool
+    {
+        $changelogData = $this->getChangelogEntry($filename, $version);
+        if (! $changelogData) {
+            $output->writeln(sprintf(
+                '<error>Unable to identify a changelog entry for %s in %s; did you specify the correct file?</error>',
+                $version,
+                $filename
+            ));
+            return false;
+        }
+
+        $this->updateChangelogEntry($filename, '', $changelogData->index, $changelogData->length);
+
+        return true;
+    }
+}

--- a/src/RemoveCommand.php
+++ b/src/RemoveCommand.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use stdClass;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class RemoveCommand extends Command
+{
+    use ChangelogEditor;
+    use GetChangelogFileTrait;
+
+    private const DESCRIPTION = 'Remove a changelog release entry.';
+
+    private const HELP = <<< 'EOH'
+Remove the given changelog release entry based on the <version> provided.
+The command will provide a preview, and prompt for confirmation before doing
+so (unless using the --force-removal flag).
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'The changelog version to remove.'
+        );
+        $this->addOption(
+            'force-removal',
+            'r',
+            InputOption::VALUE_NONE,
+            'Do not prompt for confirmation.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        // Verify we have a version argument we can work with
+        $version = $input->getArgument('version') ?: '';
+        if (! $this->validateVersion($version, $output)) {
+            return 1;
+        }
+
+        // Verify we can find the entry in the changelog file
+        $changelogFile = $this->getChangelogFile($input);
+        $entry         = $this->getChangelogEntry($changelogFile, $version);
+        if (! $entry) {
+            $output->writeln(sprintf(
+                '<error>Could not locate version %s in changelog file %s;'
+                . ' please verify the version and/or changelog file.</error>',
+                $version,
+                $changelogFile
+            ));
+            return 1;
+        }
+
+        // Have the user verify they want to remove the entry
+        if (! $input->getOption('force-removal')) {
+            $continue = $this->promptForConfirmation($input, $output, $entry);
+            if (! $continue) {
+                $output->writeln('<info>Aborting at user request</info>');
+                return 0;
+            }
+        }
+
+        if (! (new Remove())($output, $changelogFile, $version)) {
+            $output->writeln(sprintf(
+                '<error>Could not remove version %s from changelog file %s;'
+                . ' please check the output for details.</error>',
+                $version,
+                $changelogFile
+            ));
+            return 1;
+        }
+
+        $output->writeln(sprintf(
+            '<info>Removed changelog version %s from file %s.</info>',
+            $version,
+            $changelogFile
+        ));
+
+        return 0;
+    }
+
+    private function validateVersion(string $version, OutputInterface $output) : bool
+    {
+        if (! preg_match('/^\d+\.\d+\.\d+((?:alpha|a|beta|b|rc|dev)\d+)?$/i', $version)) {
+            $output->writeln(sprintf(
+                '<error>Invalid version "%s"; must follow semantic versioning rules</error>',
+                $version
+            ));
+            return false;
+        }
+
+        return true;
+    }
+
+    private function promptForConfirmation(
+        InputInterface $input,
+        OutputInterface $output,
+        stdClass $entry
+    ) : bool {
+        $output->writeln('<info>Found the following entry:</info>');
+        $output->writeln($entry->contents);
+
+        $helper   = $this->getHelper('question');
+        $question = new ConfirmationQuestion('Do you really want to delete this entry?', false);
+
+        return $helper->ask($input, $output, $question);
+    }
+}

--- a/src/ShowVersionCommand.php
+++ b/src/ShowVersionCommand.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ShowVersionCommand extends Command
+{
+    use GetChangelogFileTrait;
+
+    private const DESCRIPTION = 'Show the changelog entry for the given version.';
+
+    private const HELP = <<< 'EOH'
+Opens the changelog and displays the entry for the given version.
+EOH;
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'Which version do you wish to display?'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $version = $input->getArgument('version');
+
+        if (! preg_match('/^\d+\.\d+\.\d+/', $version)) {
+            $output->writeln('Version provided is not a semantic version; please check and retry.');
+            return 1;
+        }
+
+        $changelogFile = $this->getChangelogFile($input);
+        $changelogs    = file_get_contents($changelogFile);
+        $parser        = new ChangelogParser();
+
+        $releaseDate   = $parser->findReleaseDateForVersion($changelogs, $version);
+        $changelog     = $parser->findChangelogForVersion($changelogs, $version);
+
+        $output->writeln(sprintf(
+            '<info>Showing changelog for version %s (released %s):</info>',
+            $version,
+            $releaseDate
+        ));
+        $output->writeln('');
+        $output->write($changelog);
+        $output->writeln('');
+
+        return 0;
+    }
+}

--- a/test/ChangelogBumpTest.php
+++ b/test/ChangelogBumpTest.php
@@ -155,23 +155,23 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added a new feature.
 
 ### Changed
 
-- Nothing.
+- Made some changes.
 
 ### Deprecated
 
-- Nothing.
+- Nothing was deprecated.
 
 ### Removed
 
-- Nothing.
+- Nothing was removed.
 
 ### Fixed
 
-- Nothing.
+- Fixed some bugs.
 
 ## 0.1.0 - 2018-03-23
 

--- a/test/ChangelogParserTest.php
+++ b/test/ChangelogParserTest.php
@@ -132,4 +132,17 @@ EOF;
         $date = $this->parser->findReleaseDateForVersion($this->changelog, '2.0.0');
         $this->assertSame('TBD', $date);
     }
+
+    public function testCanRetrieveInformationOnAllVersions()
+    {
+        $expected = [
+            '2.0.0' => 'TBD',
+            '1.1.0' => '2018-03-23',
+            '0.1.0' => '2018-03-23',
+        ];
+
+        $actual = iterator_to_array($this->parser->findAllVersions(__DIR__ . '/_files/CHANGELOG.md'));
+
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/test/EditTest.php
+++ b/test/EditTest.php
@@ -177,12 +177,10 @@ EOH;
 
 
 EOH;
-        $tempFile = tempnam(sys_get_temp_dir(), 'CAK');
-        file_put_contents($tempFile, $expectedContents);
 
         $edit = new Edit();
         $updateChangelogEntry = $this->reflectMethod($edit, 'updateChangelogEntry');
-        $updateChangelogEntry->invoke($edit, $this->tempFile, $tempFile, 4, 22);
+        $updateChangelogEntry->invoke($edit, $this->tempFile, $expectedContents, 4, 22);
 
         $this->assertFileEquals(__DIR__ . '/_files/CHANGELOG-EDIT-EXPECTED.md', $this->tempFile);
     }

--- a/test/EditTest.php
+++ b/test/EditTest.php
@@ -32,7 +32,7 @@ class EditTest extends TestCase
         return $r;
     }
 
-    public function getSampleContents() : string
+    public function getVersion2Contents() : string
     {
         return <<< 'EOH'
 ## 2.0.0 - TBD
@@ -61,6 +61,36 @@ class EditTest extends TestCase
 EOH;
     }
 
+    public function getVersion1Contents() : string
+    {
+        return <<< 'EOH'
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Added a new feature.
+
+### Changed
+
+- Made some changes.
+
+### Deprecated
+
+- Nothing was deprecated.
+
+### Removed
+
+- Nothing was removed.
+
+### Fixed
+
+- Fixed some bugs.
+
+
+EOH;
+    }
+
+
     public function testGetChangelogEntryReturnsNullIfNoChangelogEntryFound()
     {
         $edit = new Edit();
@@ -68,16 +98,30 @@ EOH;
         $this->assertNull($getChangelogEntry->invoke($edit, __DIR__ . '/_files/invalid-composer/composer.json'));
     }
 
-    public function testGetChangelogEntryReturnsExpectedDataWhenChangelogIsDiscovered()
+    public function getChangelogEntryProvider() : iterable
     {
-        $expected = $this->getSampleContents();
+        $changelogFile = __DIR__ . '/_files/CHANGELOG.md';
+        yield 'latest' => [null,    $changelogFile, 4,  22, $this->getVersion2Contents()];
+        yield '1.1.0'  => ['1.1.0', $changelogFile, 26, 22, $this->getVersion1Contents()];
+    }
+
+    /**
+     * @dataProvider getChangelogEntryProvider
+     */
+    public function testGetChangelogEntryReturnsExpectedDataWhenChangelogIsDiscovered(
+        ?string $version,
+        string $changelogFile,
+        int $expectedIndex,
+        int $expectedLength,
+        string $expectedContents
+    ) {
         $edit = new Edit();
         $getChangelogEntry = $this->reflectMethod($edit, 'getChangelogEntry');
-        $data = $getChangelogEntry->invoke($edit, __DIR__ . '/_files/CHANGELOG.md');
+        $data = $getChangelogEntry->invoke($edit, $changelogFile, $version);
 
-        $this->assertEquals(4, $data->index);
-        $this->assertEquals(22, $data->length);
-        $this->assertEquals($expected, $data->contents);
+        $this->assertEquals($expectedIndex, $data->index);
+        $this->assertEquals($expectedLength, $data->length);
+        $this->assertEquals($expectedContents, $data->contents);
     }
 
     public function testUsesSystemEditorIfPresentInEnv()

--- a/test/RemoveTest.php
+++ b/test/RemoveTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog;
+
+use Phly\KeepAChangelog\Remove;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RemoveTest extends TestCase
+{
+    /** @var ?string */
+    private $filename;
+
+    public function setUp()
+    {
+        $this->filename = null;
+        $this->output   = $this->prophesize(OutputInterface::class);
+        $this->remove   = new Remove();
+    }
+
+    public function tearDown()
+    {
+        if ($this->filename) {
+            if (file_exists($this->filename)) {
+                unlink($this->filename);
+            }
+            $this->filename = null;
+        }
+    }
+
+    protected function createChangelogFile()
+    {
+        $contents       = file_get_contents(__DIR__ . '/_files/CHANGELOG.md');
+        $this->filename = $filename = tempnam(sys_get_temp_dir(), 'CAK');
+        file_put_contents($filename, $contents);
+        return $filename;
+    }
+
+    public function testReturnsFalseWhenUnableToFindVersionInChangelog()
+    {
+        $filename = $this->createChangelogFile();
+        $this->assertFalse(($this->remove)($this->output->reveal(), $filename, '1.10.0'));
+
+        $this->output
+            ->writeln(Argument::containingString('Unable to identify a changelog entry'))
+            ->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function testCanRemoveValidVersionFromChangelogFile()
+    {
+        $filename = $this->createChangelogFile();
+        $this->assertTrue(($this->remove)($this->output->reveal(), $filename, '1.1.0'));
+
+        $this->output
+            ->writeln(Argument::containingString('Unable to identify a changelog entry'))
+            ->shouldNotHaveBeenCalled();
+
+        $expected = <<< 'EOC'
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 2.0.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+EOC;
+        $actual = file_get_contents($filename);
+        $this->assertEquals($actual, $expected);
+    }
+}

--- a/test/_files/CHANGELOG-DATED-EXPECTED.md
+++ b/test/_files/CHANGELOG-DATED-EXPECTED.md
@@ -28,23 +28,23 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added a new feature.
 
 ### Changed
 
-- Nothing.
+- Made some changes.
 
 ### Deprecated
 
-- Nothing.
+- Nothing was deprecated.
 
 ### Removed
 
-- Nothing.
+- Nothing was removed.
 
 ### Fixed
 
-- Nothing.
+- Fixed some bugs.
 
 ## 0.1.0 - 2018-03-23
 

--- a/test/_files/CHANGELOG-EDIT-EXPECTED.md
+++ b/test/_files/CHANGELOG-EDIT-EXPECTED.md
@@ -28,23 +28,23 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added a new feature.
 
 ### Changed
 
-- Nothing.
+- Made some changes.
 
 ### Deprecated
 
-- Nothing.
+- Nothing was deprecated.
 
 ### Removed
 
-- Nothing.
+- Nothing was removed.
 
 ### Fixed
 
-- Nothing.
+- Fixed some bugs.
 
 ## 0.1.0 - 2018-03-23
 

--- a/test/_files/CHANGELOG-INVALID-DATE.md
+++ b/test/_files/CHANGELOG-INVALID-DATE.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
-## 1.1.0 - 2018-03-23
+## 1.1.0 - not-a-valid-date
 
 ### Added
 


### PR DESCRIPTION
This patch updates the following command:

- `edit` now accepts an optional `<version>` argument, detailing the
  version to edit. When not provided, behavior is as it was previously:
  it edits the most recent version. Otherwise, it will attempt to find
  that version in the changelog file, and allow you to edit it.

This patch also adds the following commands:

- `show-version <version>` will show the changelog entry for that
  version, along with the date it was released.

- `remove <version>` allows you to remove a specific release entry from
  the changelog file. By default, it will display it to you and ask you
  to confirm the operation; you can provide the `--force-removal` or
  `-r` flag to skip that step.

- `list-versions` will list all versions found in the changelog file,
  along with their associated release dates.