### PR TITLE
Allow GitLab subgroups in package names

### DIFF
--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -78,7 +78,8 @@ EOH;
             'package',
             null,
             InputOption::VALUE_REQUIRED,
-            'Name of package in organization/repo format (for building link to a pull request)'
+            'Name of package in organization/repo format (for building link to a pull request);'
+            . ' allows GitLab subgroups format as well'
         );
         $this->addOption(
             'provider',
@@ -208,12 +209,7 @@ EOH;
 
     private function generatePullRequestLink(int $pr, string $package, ProviderInterface $provider) : ?string
     {
-        if (! preg_match('#^[a-z0-9]+[a-z0-9_-]*/[a-z0-9]+[a-z0-9_-]*$#i', $package)) {
-            throw Exception\InvalidPackageNameException::forPackage($package);
-        }
-
         $link = $provider->generatePullRequestLink($package, $pr);
-
         return $this->probeLink($link) ? $link : null;
     }
 

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
- * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @copyright Copyright (c) 2018-2019 Matthew Weier O'Phinney
  * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
  */
 
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\Provider;
 
 use Github\Client as GitHubClient;
+use Phly\KeepAChangelog\Exception;
 
 class GitHub implements ProviderInterface
 {
@@ -54,6 +55,10 @@ class GitHub implements ProviderInterface
      */
     public function generatePullRequestLink(string $package, int $pr) : string
     {
+        if (! preg_match('#^[a-z0-9]+[a-z0-9_-]*/[a-z0-9]+[a-z0-9_-]*$#i', $package)) {
+            throw Exception\InvalidPackageNameException::forPackage($package);
+        }
+
         return sprintf('https://github.com/%s/pull/%d', $package, $pr);
     }
 }

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
- * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
+ * @copyright Copyright (c) 2018-2019 Matthew Weier O'Phinney
  * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
  */
 
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\Provider;
 
 use Gitlab\Client as GitLabClient;
+use Phly\KeepAChangelog\Exception;
 
 class GitLab implements ProviderInterface
 {
@@ -43,6 +44,10 @@ class GitLab implements ProviderInterface
      */
     public function generatePullRequestLink(string $package, int $pr) : string
     {
+        if (! preg_match('#^[a-z0-9]+[a-z0-9_-]*(/[a-z0-9]+[a-z0-9_-]*)+$#i', $package)) {
+            throw Exception\InvalidPackageNameException::forPackage($package);
+        }
+
         return sprintf('https://gitlab.com/%s/merge_requests/%d', $package, $pr);
     }
 }

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -54,7 +54,8 @@ EOH;
         $this->addArgument(
             'package',
             InputArgument::REQUIRED,
-            'Package to release; must be in org/repo format, and match the github repository name'
+            'Package to release; must be in org/repo format, and match the repository name;'
+            . ' allows GitLab subgroup format'
         );
         $this->addArgument(
             'version',
@@ -198,7 +199,8 @@ EOH;
         if ($name) {
             return $name;
         }
-        [$org, $repo] = explode('/', $package, 2);
+        $lastSeparator = strrpos($package, '/');
+        $repo          = substr($package, $lastSeparator + 1);
         return sprintf('%s %s', $repo, $version);
     }
 

--- a/test/Provider/GitHubTest.php
+++ b/test/Provider/GitHubTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Provider;
+
+use Phly\KeepAChangelog\Exception\InvalidPackageNameException;
+use Phly\KeepAChangelog\Provider\GitHub;
+use PHPUnit\Framework\TestCase;
+
+class GitHubTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->github = new GitHub();
+    }
+
+    public function invalidPackageNames() : iterable
+    {
+        yield 'empty'                 => [''];
+        yield 'invalid-vendor'        => ['@phly'];
+        yield 'vendor-only'           => ['phly'];
+        yield 'invalid-repo'          => ['phly/@invalid'];
+        yield 'invalid-subgroup'      => ['phly/subgroup/package'];
+    }
+
+    /**
+     * @dataProvider invalidPackageNames
+     */
+    public function testGeneratePullRequestLinkRaisesExceptionForInvalidPackageNames(string $package)
+    {
+        $this->expectException(InvalidPackageNameException::class);
+        $this->github->generatePullRequestLink($package, 1);
+    }
+
+    public function validPackageNames() : iterable
+    {
+        // @codingStandardsIgnoreStart
+        // @phpcs:disable
+        yield 'typical'               => ['phly/keep-a-changelog', 42, 'https://github.com/phly/keep-a-changelog/pull/42'];
+        yield 'typical-underscore'    => ['phly/keep_a_changelog', 42, 'https://github.com/phly/keep_a_changelog/pull/42'];
+        // @phpcs:enable
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider validPackageNames
+     */
+    public function testGeneratePullRequestLinkCreatesExpectedPackageLinks(string $package, int $pr, string $expected)
+    {
+        $link = $this->github->generatePullRequestLink($package, $pr);
+        $this->assertSame($expected, $link);
+    }
+}

--- a/test/Provider/GitLabTest.php
+++ b/test/Provider/GitLabTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Provider;
+
+use Phly\KeepAChangelog\Exception\InvalidPackageNameException;
+use Phly\KeepAChangelog\Provider\GitLab;
+use PHPUnit\Framework\TestCase;
+
+class GitLabTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->gitlab = new GitLab();
+    }
+
+    public function invalidPackageNames() : iterable
+    {
+        yield 'empty'                 => [''];
+        yield 'invalid-vendor'        => ['@phly'];
+        yield 'vendor-only'           => ['phly'];
+        yield 'invalid-repo'          => ['phly/@invalid'];
+        yield 'invalid-subgroup'      => ['phly/@invalid/package'];
+        yield 'invalid-subgroup-repo' => ['phly/subgroup/@package'];
+    }
+
+    /**
+     * @dataProvider invalidPackageNames
+     */
+    public function testGeneratePullRequestLinkRaisesExceptionForInvalidPackageNames(string $package)
+    {
+        $this->expectException(InvalidPackageNameException::class);
+        $this->gitlab->generatePullRequestLink($package, 1);
+    }
+
+    public function validPackageNames() : iterable
+    {
+        // @codingStandardsIgnoreStart
+        // @phpcs:disable
+        yield 'typical'               => ['phly/keep-a-changelog', 42, 'https://gitlab.com/phly/keep-a-changelog/merge_requests/42'];
+        yield 'typical-underscore'    => ['phly/keep_a_changelog', 42, 'https://gitlab.com/phly/keep_a_changelog/merge_requests/42'];
+        yield 'subgroup'              => ['phly/cli/keep-a-changelog', 42, 'https://gitlab.com/phly/cli/keep-a-changelog/merge_requests/42'];
+        // @phpcs:enable
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider validPackageNames
+     */
+    public function testGeneratePullRequestLinkCreatesExpectedPackageLinks(string $package, int $pr, string $expected)
+    {
+        $link = $this->gitlab->generatePullRequestLink($package, $pr);
+        $this->assertSame($expected, $link);
+    }
+}


### PR DESCRIPTION
This patch moves validation of the package name into the individual
providers, and expands what GitLab allows to allow subgroups in the
package name.

The various commands have been updated to indicate they allow GitLab
subgroups in package names when using GitLab and providing a package
name. Additionally, the logic in the `ReleaseCommand::createReleaseName`
method was re-worked to split the package name on the last `/` provided
(instead of using list operations with `explode`).

Fixes #34