### PR TITLE
Use correct markup for gitlab merge requests

### DIFF
--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -136,24 +136,26 @@ EOH;
             throw Exception\InvalidPullRequestException::for($pr);
         }
 
-        $config = $this->prepareConfig($input);
+        $config   = $this->prepareConfig($input);
+        $provider = $this->getProvider($config);
 
         return sprintf(
-            '[#%d](%s) %s',
+            '[%s%d](%s) %s',
+            $provider instanceof Provider\IssueMarkupProvider ? $provider->getPatchPrefix() : '#',
             (int) $pr,
-            $this->preparePullRequestLink(
+            $this->preparePatchLink(
                 (int) $pr,
                 $input->getOption('package'),
-                $this->getProvider($config)
+                $provider
             ),
             $entry
         );
     }
 
-    private function preparePullRequestLink(int $pr, ?string $package, ProviderInterface $provider) : string
+    private function preparePatchLink(int $pr, ?string $package, ProviderInterface $provider) : string
     {
         if (null !== $package) {
-            $link = $this->generatePullRequestLink($pr, $package, $provider);
+            $link = $this->generatePatchLink($pr, $package, $provider);
 
             if (null === $link) {
                 throw Exception\InvalidPullRequestLinkException::forPackage($package, $pr);
@@ -162,14 +164,14 @@ EOH;
             return $link;
         }
 
-        $link = $this->generatePullRequestLink($pr, (new ComposerPackage())->getName(realpath(getcwd())), $provider);
+        $link = $this->generatePatchLink($pr, (new ComposerPackage())->getName(realpath(getcwd())), $provider);
 
         if (null !== $link) {
             return $link;
         }
 
         foreach ($this->getPackageNames($provider) as $package) {
-            $link = $this->generatePullRequestLink($pr, $package, $provider);
+            $link = $this->generatePatchLink($pr, $package, $provider);
 
             if (null !== $link) {
                 return $link;
@@ -207,7 +209,7 @@ EOH;
         return $packages;
     }
 
-    private function generatePullRequestLink(int $pr, string $package, ProviderInterface $provider) : ?string
+    private function generatePatchLink(int $pr, string $package, ProviderInterface $provider) : ?string
     {
         $link = $provider->generatePullRequestLink($package, $pr);
         return $this->probeLink($link) ? $link : null;

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -12,8 +12,20 @@ namespace Phly\KeepAChangelog\Provider;
 use Github\Client as GitHubClient;
 use Phly\KeepAChangelog\Exception;
 
-class GitHub implements ProviderInterface
+class GitHub implements
+    IssueMarkupProvider,
+    ProviderInterface
 {
+    public function getIssuePrefix() : string
+    {
+        return '#';
+    }
+
+    public function getPatchPrefix() : string
+    {
+        return '#';
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -12,8 +12,20 @@ namespace Phly\KeepAChangelog\Provider;
 use Gitlab\Client as GitLabClient;
 use Phly\KeepAChangelog\Exception;
 
-class GitLab implements ProviderInterface
+class GitLab implements
+    IssueMarkupProvider,
+    ProviderInterface
 {
+    public function getIssuePrefix() : string
+    {
+        return '#';
+    }
+
+    public function getPatchPrefix() : string
+    {
+        return '!';
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Provider/IssueMarkupProvider.php
+++ b/src/Provider/IssueMarkupProvider.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Provider;
+
+interface IssueMarkupProvider
+{
+    /**
+     * Retrieve the prefix to use when generating markup for an issue.
+     *
+     * GitHub uses `#` to reference either issues or pull requests.
+     * GitLab uses `#` for issues, and `!` for merge requests.
+     */
+    public function getIssuePrefix() : string;
+
+    /**
+     * Retrieve the prefix to use when generating markup for a patch.
+     *
+     * GitHub uses `#` to reference either issues or pull requests.
+     * GitLab uses `#` for issues, and `!` for merge requests.
+     */
+    public function getPatchPrefix() : string;
+}

--- a/test/EntryCommandTest.php
+++ b/test/EntryCommandTest.php
@@ -176,7 +176,7 @@ class EntryCommandTest extends TestCase
         $command = new EntryCommand('entry:added');
         $this->injectCommandConfigPaths($command);
 
-        $expected = '[#1](https://gitlab.com/phly/keep-a-changelog/merge_requests/1) ' . $entry;
+        $expected = '[!1](https://gitlab.com/phly/keep-a-changelog/merge_requests/1) ' . $entry;
 
         $this->assertSame(
             $expected,


### PR DESCRIPTION
In GitLab, merge requests use `!` as a prefix, while issues use `#` — versus GitHub, which uses `#` for both.

This patch adds the prefix `IssueMarkupProvider`, with the methods `getPatchPrefix()` and `getIssuePrefix()`. Both the `GitHub` and `GitLab` providers were updated to implement this new interface, and `EntryCommand` now uses that method to pull the prefix when generating PR links, if the provider implements the interface.

Fixes #36