### PR TITLE
Add `bump:patch` as an alias to `bump` and `bump:bugfix`

### DIFF
--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -38,6 +38,7 @@ $application->getDefinition()
 $application->addCommands([
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump'),
     new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump:bugfix'),
+    new BumpCommand(BumpCommand::BUMP_BUGFIX, 'bump:patch'),
     new BumpCommand(BumpCommand::BUMP_MINOR, 'bump:minor'),
     new BumpCommand(BumpCommand::BUMP_MAJOR, 'bump:major'),
     new BumpToVersionCommand('bump:to-version'),

--- a/src/BumpCommand.php
+++ b/src/BumpCommand.php
@@ -26,6 +26,7 @@ class BumpCommand extends Command
     public const BUMP_BUGFIX = 'bugfix';
     public const BUMP_MAJOR = 'major';
     public const BUMP_MINOR = 'minor';
+    public const BUMP_PATCH = self::BUMP_BUGFIX;
 
     private const DESC_TEMPLATE = 'Create a new changelog entry for the next %s release.';
 


### PR DESCRIPTION
This patch adds `bump:patch` as an alias to `bump` and `bump:bugfix`.

Fixes #40