### PR TITLE
Use the configured remote when pushing tags

### DIFF
--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\Exception;
 
 use InvalidArgumentException;
+use Phly\KeepAChangelog\Provider;
 
 class InvalidProviderException extends InvalidArgumentException
 {
@@ -19,6 +20,17 @@ class InvalidProviderException extends InvalidArgumentException
             'Unknown provider "%s"; must be one of (%s)',
             $provider,
             implode(', ', $allowedProviders)
+        ));
+    }
+
+    public static function forIncompleteProvider(Provider\ProviderInterface $provider) : self
+    {
+        return new self(sprintf(
+            'Provider %s does not implement %s and thus cannot be used to determine where to push tags;'
+            . ' please implement %s',
+            gettype($provider),
+            Provider\ProviderNameProvider::class,
+            Provider\ProviderNameProvider::class
         ));
     }
 }

--- a/src/Exception/MissingTagException.php
+++ b/src/Exception/MissingTagException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class MissingTagException extends RuntimeException
 {
@@ -19,5 +20,37 @@ class MissingTagException extends RuntimeException
             'No tag found by the name %s found in current directory.',
             $version
         ));
+    }
+
+    public static function forPackageOnGithub(string $package, string $version, Throwable $e) : self
+    {
+        return new self(sprintf(
+            'When verifying that the tag %s for package %s is present on GitHub,'
+            . ' no corresponding tag was found',
+            $version,
+            $package
+        ), $e->getCode(), $e);
+    }
+
+    public static function forTagOnGithub(string $package, string $version, Throwable $e) : self
+    {
+        return new self(sprintf(
+            'When verifying that the tag %s for package %s is present on GitHub,'
+            . ' an error occurred fetching tag details: %s',
+            $version,
+            $package,
+            $e->getMessage()
+        ), $e->getCode(), $e);
+    }
+
+    public static function forUnverifiedTagOnGithub(string $package, string $version, Throwable $e) : self
+    {
+        return new self(sprintf(
+            'When verifying that the tag %s for package %s is present on GitHub,'
+            . ' the tag found was unsigned. Please recreate the tag using the'
+            . ' -s flag.',
+            $version,
+            $package
+        ), $e->getCode(), $e);
     }
 }

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -14,7 +14,8 @@ use Phly\KeepAChangelog\Exception;
 
 class GitHub implements
     IssueMarkupProvider,
-    ProviderInterface
+    ProviderInterface,
+    ProviderNameProvider
 {
     public function getIssuePrefix() : string
     {
@@ -72,5 +73,15 @@ class GitHub implements
         }
 
         return sprintf('https://github.com/%s/pull/%d', $package, $pr);
+    }
+
+    public function getName() : string
+    {
+        return 'GitHub';
+    }
+
+    public function getDomainName() : string
+    {
+        return 'github.com';
     }
 }

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -14,7 +14,8 @@ use Phly\KeepAChangelog\Exception;
 
 class GitLab implements
     IssueMarkupProvider,
-    ProviderInterface
+    ProviderInterface,
+    ProviderNameProvider
 {
     public function getIssuePrefix() : string
     {
@@ -61,5 +62,15 @@ class GitLab implements
         }
 
         return sprintf('https://gitlab.com/%s/merge_requests/%d', $package, $pr);
+    }
+
+    public function getName() : string
+    {
+        return 'GitLab';
+    }
+
+    public function getDomainName() : string
+    {
+        return 'gitlab.com';
     }
 }

--- a/src/Provider/ProviderNameProvider.php
+++ b/src/Provider/ProviderNameProvider.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Provider;
+
+interface ProviderNameProvider
+{
+    /**
+     * Return the name of the provider (e.g. github, gitlab)
+     */
+    public function getName() : string;
+
+    /**
+     * Return the domain name of the provider (e.g., github.com)
+     */
+    public function getDomainName() : string;
+}

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -181,7 +181,7 @@ EOH;
         );
         if (! $release) {
             $output->writeln('<error>Error creating release!</error>');
-            $output->writeln('Check the output logs for details');
+            $output->writeln('Check the output logs for details, or re-run this command with verbosity turned on');
             return 1;
         }
 

--- a/test/LookupRemoteTest.php
+++ b/test/LookupRemoteTest.php
@@ -13,10 +13,22 @@ use Phly\KeepAChangelog\Exception\InvalidProviderException;
 use Phly\KeepAChangelog\Provider;
 use Phly\KeepAChangelog\ReleaseCommand;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use ReflectionMethod;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class LookupRemoteTest extends TestCase
 {
+    public function setUp()
+    {
+        $this->input  = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+    }
+
     public function getMethod()
     {
         $command = new ReleaseCommand();
@@ -49,7 +61,13 @@ class LookupRemoteTest extends TestCase
         };
 
         $this->expectException(InvalidProviderException::class);
-        ($this->getMethod())($provider, 'phly/keep-a-changelog', []);
+        ($this->getMethod())(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $provider,
+            'phly/keep-a-changelog',
+            []
+        );
     }
 
     public function testLookupRemoteReturnsNullIfUnableToMatchRemotesToProviderAndPackage()
@@ -83,19 +101,25 @@ class LookupRemoteTest extends TestCase
             }
         };
 
-        $remote = ($this->getMethod())($provider, 'phly/keep-a-changelog', [
-            "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
-            "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
-            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
-            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
-            "custom\tgit@github.com:phly/keep-a-changelog.git\t(fetch)",
-            "custom\tgit@github.com:phly/keep-a-changelog.git\t(push)",
-        ]);
+        $remote = ($this->getMethod())(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $provider,
+            'phly/keep-a-changelog',
+            [
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+                "custom\tgit@github.com:phly/keep-a-changelog.git\t(fetch)",
+                "custom\tgit@github.com:phly/keep-a-changelog.git\t(push)",
+            ]
+        );
 
         $this->assertNull($remote);
     }
 
-    public function testLookupRemoteReturnsRemoteNameForFirstRemoteThatMatchesProviderAndPackage()
+    public function testLookupRemoteReturnsRemoteWhenExactlyOneMatches()
     {
         $provider = new class implements Provider\ProviderInterface, Provider\ProviderNameProvider {
             public function createRelease(
@@ -126,17 +150,186 @@ class LookupRemoteTest extends TestCase
             }
         };
 
-        $remote = ($this->getMethod())($provider, 'phly/keep-a-changelog', [
-            "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
-            "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
-            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
-            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
-            "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(fetch)",
-            "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(push)",
-            "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(fetch)",
-            "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(push)",
-        ]);
+        $remote = ($this->getMethod())(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $provider,
+            'phly/keep-a-changelog',
+            [
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(fetch)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(push)",
+            ]
+        );
 
         $this->assertSame('custom', $remote);
+    }
+
+    public function testLookupRemotePromptsUserWhenMultipleMatchesFound()
+    {
+        $provider = new class implements Provider\ProviderInterface, Provider\ProviderNameProvider {
+            public function createRelease(
+                string $package,
+                string $releaseName,
+                string $tagName,
+                string $changelog,
+                string $token
+            ) : ?string {
+            }
+
+            public function getRepositoryUrlRegex() : string
+            {
+            }
+
+            public function generatePullRequestLink(string $package, int $pr) : string
+            {
+            }
+
+            public function getName() : string
+            {
+                return 'custom';
+            }
+
+            public function getDomainName() : string
+            {
+                return 'custom.develop';
+            }
+        };
+
+        $questionHelper = $this->prophesize(QuestionHelper::class);
+        $questionHelper
+            ->ask(
+                Argument::that([$this->input, 'reveal']),
+                Argument::that([$this->output, 'reveal']),
+                Argument::that(function ($question) {
+                    TestCase::assertInstanceOf(ChoiceQuestion::class, $question);
+                    TestCase::assertRegExp('/more than one valid remote/i', $question->getQuestion());
+                    TestCase::assertEquals([
+                        'custom',
+                        'customHttps',
+                        'abort' => 'Abort release',
+                    ], $question->getChoices());
+
+                    return $question;
+                })
+            )
+            ->willReturn('customHttps');
+
+        $helperSet = $this->prophesize(HelperSet::class);
+        $helperSet->get('question')->will([$questionHelper, 'reveal']);
+
+        $command = new ReleaseCommand();
+        $command->setHelperSet($helperSet->reveal());
+
+        $r = new ReflectionMethod($command, 'lookupRemote');
+        $r->setAccessible(true);
+        $method = function (...$arguments) use ($r, $command) {
+            return $r->invokeArgs($command, $arguments);
+        };
+
+        $remote = $method(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $provider,
+            'phly/keep-a-changelog',
+            [
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(fetch)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(push)",
+                "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(fetch)",
+                "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(push)",
+            ]
+        );
+
+        $this->assertSame('customHttps', $remote);
+    }
+
+    public function testCanAbortWhenMultipleMatchesFound()
+    {
+        $provider = new class implements Provider\ProviderInterface, Provider\ProviderNameProvider {
+            public function createRelease(
+                string $package,
+                string $releaseName,
+                string $tagName,
+                string $changelog,
+                string $token
+            ) : ?string {
+            }
+
+            public function getRepositoryUrlRegex() : string
+            {
+            }
+
+            public function generatePullRequestLink(string $package, int $pr) : string
+            {
+            }
+
+            public function getName() : string
+            {
+                return 'custom';
+            }
+
+            public function getDomainName() : string
+            {
+                return 'custom.develop';
+            }
+        };
+
+        $questionHelper = $this->prophesize(QuestionHelper::class);
+        $questionHelper
+            ->ask(
+                Argument::that([$this->input, 'reveal']),
+                Argument::that([$this->output, 'reveal']),
+                Argument::that(function ($question) {
+                    TestCase::assertInstanceOf(ChoiceQuestion::class, $question);
+                    TestCase::assertRegExp('/more than one valid remote/i', $question->getQuestion());
+                    TestCase::assertEquals([
+                        'custom',
+                        'customHttps',
+                        'abort' => 'Abort release',
+                    ], $question->getChoices());
+
+                    return $question;
+                })
+            )
+            ->willReturn('Abort release');
+
+        $helperSet = $this->prophesize(HelperSet::class);
+        $helperSet->get('question')->will([$questionHelper, 'reveal']);
+
+        $command = new ReleaseCommand();
+        $command->setHelperSet($helperSet->reveal());
+
+        $r = new ReflectionMethod($command, 'lookupRemote');
+        $r->setAccessible(true);
+        $method = function (...$arguments) use ($r, $command) {
+            return $r->invokeArgs($command, $arguments);
+        };
+
+        $remote = $method(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $provider,
+            'phly/keep-a-changelog',
+            [
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+                "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(fetch)",
+                "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(push)",
+                "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(fetch)",
+                "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(push)",
+            ]
+        );
+
+        $this->assertNull($remote);
+        $this->output->writeln(Argument::containingString('Aborted'))->shouldHaveBeenCalled();
     }
 }

--- a/test/LookupRemoteTest.php
+++ b/test/LookupRemoteTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog;
+
+use Phly\KeepAChangelog\Exception\InvalidProviderException;
+use Phly\KeepAChangelog\Provider;
+use Phly\KeepAChangelog\ReleaseCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class LookupRemoteTest extends TestCase
+{
+    public function getMethod()
+    {
+        $command = new ReleaseCommand();
+        $r = new ReflectionMethod($command, 'lookupRemote');
+        $r->setAccessible(true);
+        return function (...$arguments) use ($r, $command) {
+            return $r->invokeArgs($command, $arguments);
+        };
+    }
+
+    public function testLookupRemoteRaisesExceptionIfProviderCannotProvideName()
+    {
+        $provider = new class implements Provider\ProviderInterface {
+            public function createRelease(
+                string $package,
+                string $releaseName,
+                string $tagName,
+                string $changelog,
+                string $token
+            ) : ?string {
+            }
+
+            public function getRepositoryUrlRegex() : string
+            {
+            }
+
+            public function generatePullRequestLink(string $package, int $pr) : string
+            {
+            }
+        };
+
+        $this->expectException(InvalidProviderException::class);
+        ($this->getMethod())($provider, 'phly/keep-a-changelog', []);
+    }
+
+    public function testLookupRemoteReturnsNullIfUnableToMatchRemotesToProviderAndPackage()
+    {
+        $provider = new class implements Provider\ProviderInterface, Provider\ProviderNameProvider {
+            public function createRelease(
+                string $package,
+                string $releaseName,
+                string $tagName,
+                string $changelog,
+                string $token
+            ) : ?string {
+            }
+
+            public function getRepositoryUrlRegex() : string
+            {
+            }
+
+            public function generatePullRequestLink(string $package, int $pr) : string
+            {
+            }
+
+            public function getName() : string
+            {
+                return 'custom';
+            }
+
+            public function getDomainName() : string
+            {
+                return 'custom.develop';
+            }
+        };
+
+        $remote = ($this->getMethod())($provider, 'phly/keep-a-changelog', [
+            "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+            "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+            "custom\tgit@github.com:phly/keep-a-changelog.git\t(fetch)",
+            "custom\tgit@github.com:phly/keep-a-changelog.git\t(push)",
+        ]);
+
+        $this->assertNull($remote);
+    }
+
+    public function testLookupRemoteReturnsRemoteNameForFirstRemoteThatMatchesProviderAndPackage()
+    {
+        $provider = new class implements Provider\ProviderInterface, Provider\ProviderNameProvider {
+            public function createRelease(
+                string $package,
+                string $releaseName,
+                string $tagName,
+                string $changelog,
+                string $token
+            ) : ?string {
+            }
+
+            public function getRepositoryUrlRegex() : string
+            {
+            }
+
+            public function generatePullRequestLink(string $package, int $pr) : string
+            {
+            }
+
+            public function getName() : string
+            {
+                return 'custom';
+            }
+
+            public function getDomainName() : string
+            {
+                return 'custom.develop';
+            }
+        };
+
+        $remote = ($this->getMethod())($provider, 'phly/keep-a-changelog', [
+            "origin\tgit://github.com/phly/keep-a-changelog.git\t(fetch)",
+            "origin\tgit://github.com/phly/keep-a-changelog.git\t(push)",
+            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(fetch)",
+            "upstream\thttps://github.com/phly/keep-a-changelog.git\t(push)",
+            "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(fetch)",
+            "custom\tgit@custom.develop:phly/keep-a-changelog.git\t(push)",
+            "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(fetch)",
+            "customHttps\thttps://custom.develop:phly/keep-a-changelog.git\t(push)",
+        ]);
+
+        $this->assertSame('custom', $remote);
+    }
+}


### PR DESCRIPTION
This patch modifies the `release` command such that it now looks up which remote to push a tag to based on:

- remotes configured for PUSH operations
- remote URLs matching the provider domain name
- remote URLs matching the package name in the path

The name of the first remote to satisfy all three criteria is returned and used for pushing tags. Otherwise, the command indicates an error occurred, provides information for debugging why, and exits with a failure status.

Additionally, this patch provides additional logic in the `GitHub` provider to verify the tag before attempting to create a release. It looks for:

- A git reference matching the given tag.
- Tag details matching the sha reference for the tag.
- Tag verification in the tag details.

If any of these three fails, release creation will raise an exception, causing the command to abort.

Between these two changes, tag pushes and release creation should only ever occur on the canonical repository, for signed tags.

Fixes #39