### PR TITLE
Allow providing custom domain name for provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#46](https://github.com/phly/keep-a-changelog/pull/46) adds the `--provider-domain` option to each of the `entry:*` and `release`
+  commands, and the corresponding `domain` key in `.keep-a-changelog.ini` files.
+  The option can be used to specify a custom domain for your chosen provider; it
+  will be used to determine which git remote to push tags to, to generate links
+  for changelog entries, and to make API calls to the provider.
+
 - [#44](https://github.com/phly/keep-a-changelog/pull/44) adds the command `bump:patch` as an alias to `bump`/`bump:bugfix`.
 
 - [#33](https://github.com/phly/keep-a-changelog/pull/33) adds support for usage with the symfony/console 3.4 series.

--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -75,7 +75,10 @@ EOH;
         $question = new Question('Please enter the personal token for the provider (Empty to skip)', '');
         $token = $helper->ask($input, $output, $question);
 
-        $config = new Config($token, $provider);
+        $question = new Question('Please enter the custom domain for the provider, if any (Empty to skip)', '');
+        $domain = $helper->ask($input, $output, $question);
+
+        $config = new Config($token, $provider, $domain);
 
         $this->saveConfigFile($configFile, $config);
 

--- a/src/ConfigFileTrait.php
+++ b/src/ConfigFileTrait.php
@@ -83,6 +83,10 @@ trait ConfigFileTrait
     private function createConfigFromFile(string $configFile) : Config
     {
         $ini = parse_ini_file($configFile);
-        return new Config($ini['token'] ?? '', $ini['provider'] ?? Config::PROVIDER_GITHUB);
+        return new Config(
+            $ini['token'] ?? '',
+            $ini['provider'] ?? Config::PROVIDER_GITHUB,
+            $ini['domain'] ?? ''
+        );
     }
 }

--- a/src/EntryCommand.php
+++ b/src/EntryCommand.php
@@ -88,6 +88,12 @@ EOH;
             'Repository provider. Options: github or gitlab; defaults to github'
         );
         $this->addOption(
+            'provider-domain',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Custom domain for use with repository provider; primarily applies to self-hosted gitlab'
+        );
+        $this->addOption(
             'global',
             'g',
             InputOption::VALUE_NONE,

--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -33,4 +33,12 @@ class InvalidProviderException extends InvalidArgumentException
             Provider\ProviderNameProvider::class
         ));
     }
+
+    public static function forInvalidProviderDomain(string $domain) : self
+    {
+        return new self(sprintf(
+            'Domain "%s" is invalid, and cannot be used to with changelog providers %s',
+            $domain
+        ));
+    }
 }

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -27,7 +27,8 @@ trait GetConfigValuesTrait
     private function prepareConfig(
         InputInterface $input,
         string $tokenOptionName = 'token',
-        string $providerOptionName = 'provider'
+        string $providerOptionName = 'provider',
+        string $providerDomainOptionName = 'provider-domain'
     ) : Config {
         $config = $this->getConfig($input);
 
@@ -37,7 +38,15 @@ trait GetConfigValuesTrait
         $provider = $input->getOption($providerOptionName);
         $config = $provider ? $config->withProvider($provider) : $config;
 
+        $domain = $input->getOption($providerDomainOptionName);
+        $config = $config->withDomain((string) $domain);
+
         return $config;
+    }
+
+    private function getDomain(Config $config) : string
+    {
+        return trim($config->domain());
     }
 
     private function getProvider(Config $config) : Provider\ProviderInterface
@@ -50,10 +59,10 @@ trait GetConfigValuesTrait
 
         switch ($provider) {
             case 'github':
-                $this->provider = new Provider\GitHub();
+                $this->provider = (new Provider\GitHub())->withDomainName($this->getDomain($config));
                 break;
             case 'gitlab':
-                $this->provider = new Provider\GitLab();
+                $this->provider = (new Provider\GitLab())->withDomainName($this->getDomain($config));
                 break;
             default:
                 throw Exception\InvalidProviderException::forProvider($provider);

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -18,6 +18,9 @@ class GitHub implements
     ProviderInterface,
     ProviderNameProvider
 {
+    /** @var string */
+    private $domain = 'github.com';
+
     public function getIssuePrefix() : string
     {
         return '#';
@@ -86,7 +89,14 @@ class GitHub implements
 
     public function getDomainName() : string
     {
-        return 'github.com';
+        return $this->domain;
+    }
+
+    public function withDomainName(string $domain) : ProviderNameProvider
+    {
+        $new = clone $this;
+        $new->domain = $domain;
+        return $new;
     }
 
     /**

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -17,6 +17,9 @@ class GitLab implements
     ProviderInterface,
     ProviderNameProvider
 {
+    /** @var string */
+    private $domain = 'gitlab.com';
+
     public function getIssuePrefix() : string
     {
         return '#';
@@ -37,7 +40,7 @@ class GitLab implements
         string $changelog,
         string $token
     ) : ?string {
-        $client = GitLabClient::create('https://gitlab.com');
+        $client = GitLabClient::create('https://' . $this->getDomainName());
         $client->authenticate($token, GitLabClient::AUTH_HTTP_TOKEN);
         $release = $client->api('repositories')->createRelease($package, $tagName, $changelog);
 
@@ -49,7 +52,7 @@ class GitLab implements
      */
     public function getRepositoryUrlRegex() : string
     {
-        return '(gitlab.com[:/](.*?)\.git)';
+        return sprintf('(%s[:/](.*?)\.git)', preg_quote($this->getDomainName()));
     }
 
     /**
@@ -61,7 +64,7 @@ class GitLab implements
             throw Exception\InvalidPackageNameException::forPackage($package);
         }
 
-        return sprintf('https://gitlab.com/%s/merge_requests/%d', $package, $pr);
+        return sprintf('https://%s/%s/merge_requests/%d', $this->getDomainName(), $package, $pr);
     }
 
     public function getName() : string
@@ -71,6 +74,13 @@ class GitLab implements
 
     public function getDomainName() : string
     {
-        return 'gitlab.com';
+        return $this->domain;
+    }
+
+    public function withDomainName(string $domain) : ProviderNameProvider
+    {
+        $new = clone $this;
+        $new->domain = $domain;
+        return $new;
     }
 }

--- a/src/Provider/ProviderNameProvider.php
+++ b/src/Provider/ProviderNameProvider.php
@@ -20,4 +20,9 @@ interface ProviderNameProvider
      * Return the domain name of the provider (e.g., github.com)
      */
     public function getDomainName() : string;
+
+    /**
+     * Create a new instance with the given domain name.
+     */
+    public function withDomainName(string $domain) : self;
 }

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -94,6 +94,12 @@ EOH;
             'Repository provider. Options: github or gitlab; defaults to github'
         );
         $this->addOption(
+            'provider-domain',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Custom domain for use with repository provider; primarily applies to self-hosted gitlab'
+        );
+        $this->addOption(
             'global',
             'g',
             InputOption::VALUE_NONE,
@@ -142,6 +148,7 @@ EOH;
         }
 
         $provider = $this->getProvider($config);
+
         $remote   = $input->getOption('remote') ?: $this->lookupRemote(
             $input,
             $output,

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -28,23 +28,41 @@ class ConfigTest extends TestCase
         $this->assertSame(Config::PROVIDER_GITHUB, $config->provider());
     }
 
-    public function testConstructorAllowsProvidingBothArguments()
+    public function testConstructorAllowsProvidingProviderArgument()
     {
         $config = new Config('token-value', Config::PROVIDER_GITLAB);
         $this->assertSame('token-value', $config->token());
         $this->assertSame(Config::PROVIDER_GITLAB, $config->provider());
+        $this->assertSame('gitlab.com', $config->domain());
+    }
+
+    public function testConstructorAllowsProvidingProviderAndProviderDomainArguments()
+    {
+        $config = new Config('token-value', Config::PROVIDER_GITLAB, 'gitlab.phly.dev');
+        $this->assertSame('token-value', $config->token());
+        $this->assertSame(Config::PROVIDER_GITLAB, $config->provider());
+        $this->assertSame('gitlab.phly.dev', $config->domain());
         return $config;
     }
 
     /**
-     * @depends testConstructorAllowsProvidingBothArguments
+     * @depends testConstructorAllowsProvidingProviderAndProviderDomainArguments
      */
     public function testGetArrayCopyProvidesSerialization(Config $config)
     {
         $this->assertSame([
-            'token' => $config->token(),
+            'token'    => $config->token(),
             'provider' => $config->provider(),
+            'domain'   => $config->domain(),
         ], $config->getArrayCopy());
+    }
+
+    public function testWithDomainReturnsNewInstanceWithChangedDomain()
+    {
+        $config = new Config();
+        $changed = $config->withDomain('gitlab.phly.dev');
+        $this->assertNotSame($changed, $config);
+        $this->assertSame('gitlab.phly.dev', $changed->domain());
     }
 
     public function testWithTokenReturnsNewInstanceWithChangedToken()

--- a/test/EntryCommandTest.php
+++ b/test/EntryCommandTest.php
@@ -102,6 +102,7 @@ class EntryCommandTest extends TestCase
         $this->input->hasOption('token')->willReturn(false);
         $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
+        $this->input->getOption('provider-domain')->willReturn('');
 
         $command = new EntryCommand('entry:added');
         $this->injectCommandConfigPaths($command);
@@ -124,6 +125,7 @@ class EntryCommandTest extends TestCase
         $this->input->hasOption('token')->willReturn(false);
         $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
+        $this->input->getOption('provider-domain')->willReturn('');
 
         $command = new EntryCommand('entry:added');
         $this->injectCommandConfigPaths($command);
@@ -146,6 +148,7 @@ class EntryCommandTest extends TestCase
         $this->input->hasOption('token')->willReturn(false);
         $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
+        $this->input->getOption('provider-domain')->willReturn('');
 
         $command = new EntryCommand('entry:added');
         $this->injectCommandConfigPaths($command);
@@ -172,6 +175,7 @@ class EntryCommandTest extends TestCase
         $this->input->hasOption('token')->willReturn(false);
         $this->input->getOption('token')->shouldNotBeCalled();
         $this->input->getOption('provider')->willReturn($provider);
+        $this->input->getOption('provider-domain')->willReturn('');
 
         $command = new EntryCommand('entry:added');
         $this->injectCommandConfigPaths($command);

--- a/test/LookupRemoteTest.php
+++ b/test/LookupRemoteTest.php
@@ -99,6 +99,11 @@ class LookupRemoteTest extends TestCase
             {
                 return 'custom.develop';
             }
+
+            public function withDomainName(string $domain) : Provider\ProviderNameProvider
+            {
+                // no-op
+            }
         };
 
         $remote = ($this->getMethod())(
@@ -148,6 +153,11 @@ class LookupRemoteTest extends TestCase
             {
                 return 'custom.develop';
             }
+
+            public function withDomainName(string $domain) : Provider\ProviderNameProvider
+            {
+                // no-op
+            }
         };
 
         $remote = ($this->getMethod())(
@@ -196,6 +206,11 @@ class LookupRemoteTest extends TestCase
             public function getDomainName() : string
             {
                 return 'custom.develop';
+            }
+
+            public function withDomainName(string $domain) : Provider\ProviderNameProvider
+            {
+                // no-op
             }
         };
 
@@ -278,6 +293,11 @@ class LookupRemoteTest extends TestCase
             public function getDomainName() : string
             {
                 return 'custom.develop';
+            }
+
+            public function withDomainName(string $domain) : Provider\ProviderNameProvider
+            {
+                // no-op
             }
         };
 


### PR DESCRIPTION
Per a request made on #45, this patch makes the provider domain configurable. GitLab allows users to self-host or set a CNAME for the installation. As such, the domain name can vary from just `gitlab.com`.

This patch adds the ability to specify the domain name in relevant commands via:

- The `--provider-domain` option
- The `domain` configuration key in the `.keep-a-changelog.ini` config file

When provided, that domain will be used for determining the git remote to which to push tags, as well as for creating URLs for creating releases and changelog merge request links.