### PR TITLE
Create .keep-a-changelog directory in global location if does not exist

### DIFF
--- a/src/ConfigFileTrait.php
+++ b/src/ConfigFileTrait.php
@@ -57,6 +57,12 @@ trait ConfigFileTrait
         foreach ($config->getArrayCopy() as $key => $value) {
             $ini .= sprintf('%s = %s%s', $key, $value, PHP_EOL);
         }
+
+        $dirname = dirname($filename);
+        if (! is_dir($dirname)) {
+            mkdir($dirname, 0777, true);
+        }
+
         return file_put_contents($filename, $ini) !== false;
     }
 

--- a/test/ConfigCommandTest.php
+++ b/test/ConfigCommandTest.php
@@ -33,7 +33,7 @@ class ConfigCommandTest extends TestCase
         $this->globalPath = sprintf('%s/global', $rootPath);
         $this->localPath  = sprintf('%s/local', $rootPath);
 
-        mkdir(sprintf('%s/.keep-a-changelog', $this->globalPath), 0777, true);
+        mkdir($this->globalPath, 0777, true);
         mkdir($this->localPath, 0777, true);
     }
 
@@ -70,6 +70,7 @@ class ConfigCommandTest extends TestCase
 
     public function testExecutionRaisesExceptionWhenGlobalFileExistsAndOverwriteNotRequested()
     {
+        mkdir($this->globalPath . '/.keep-a-changelog', 0777, true);
         $configFile = sprintf('%s/.keep-a-changelog/config.ini', $this->globalPath);
         file_put_contents($configFile, 'provider = github');
 
@@ -218,6 +219,7 @@ class ConfigCommandTest extends TestCase
 
     public function testExecutionCanOverwriteGlobalConfigFile()
     {
+        mkdir($this->globalPath . '/.keep-a-changelog', 0777, true);
         $file = sprintf('%s/.keep-a-changelog/config.ini', $this->globalPath);
         file_put_contents($file, "token = original-token\nprovider = github");
 

--- a/test/EntryCommandTest.php
+++ b/test/EntryCommandTest.php
@@ -30,7 +30,7 @@ class EntryCommandTest extends TestCase
         $rootPath = vfsStream::url('config');
         $this->globalPath  = sprintf('%s/global', $rootPath);
         $this->localPath  = sprintf('%s/local', $rootPath);
-        mkdir($this->globalPath . '/.keep-a-changelog', 0777, true);
+        mkdir($this->globalPath, 0777, true);
         mkdir($this->localPath, 0777, true);
     }
 


### PR DESCRIPTION
What I did is:
- `composer global require phly/keep-a-changelog`

As I already have global composer bin directory in my `$PATH` I run:
- `keep-a-changelog` and I got list of the commands.

Then I wanted to configure it globally, so I run:
- `keep-a-changelog config -g`
and answered on all questions and I got the following error:

```
Warning: file_put_contents(/home/.keep-a-changelog/config.ini): failed to open stream: No such file or directory in /home/.composer/vendor/phly/keep-a-changelog/src/ConfigFileTrait.php on line 60

Call Stack:
    0.0004     371160   1. {main}() /home/.composer/vendor/phly/keep-a-changelog/bin/keep-a-changelog:0
    0.0544    1806760   2. Symfony\Component\Console\Application->run() /home/.composer/vendor/phly/keep-a-changelog/bin/keep-a-changelog:61
    0.0753    2078264   3. Symfony\Component\Console\Application->doRun() /home/.composer/vendor/symfony/console/Application.php:145
    0.0790    2087688   4. Symfony\Component\Console\Application->doRunCommand() /home/.composer/vendor/symfony/console/Application.php:269
    0.0791    2087688   5. Phly\KeepAChangelog\ConfigCommand->run() /home/.composer/vendor/symfony/console/Application.php:908
    0.0793    2090192   6. Phly\KeepAChangelog\ConfigCommand->execute() /home/.composer/vendor/symfony/console/Command/Command.php:255
  110.0385    2218952   7. Phly\KeepAChangelog\ConfigCommand->saveConfigFile() /home/.composer/vendor/phly/keep-a-changelog/src/ConfigCommand.php:83
  110.0386    2219064   8. file_put_contents() /home/.composer/vendor/phly/keep-a-changelog/src/ConfigFileTrait.php:60
```

Maybe the workflow should be different. I don't know. When I created `.keep-a-changelog` directory manually all works as expected.