### PR TITLE
Added colon and space before user input

### DIFF
--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -72,10 +72,10 @@ EOH;
         $question->setErrorMessage('Provider %s is invalid.');
         $provider = $helper->ask($input, $output, $question);
 
-        $question = new Question('Please enter the personal token for the provider (Empty to skip)', '');
+        $question = new Question('Please enter the personal token for the provider (Empty to skip): ', '');
         $token = $helper->ask($input, $output, $question);
 
-        $question = new Question('Please enter the custom domain for the provider, if any (Empty to skip)', '');
+        $question = new Question('Please enter the custom domain for the provider, if any (Empty to skip): ', '');
         $domain = $helper->ask($input, $output, $question);
 
         $config = new Config($token, $provider, $domain);


### PR DESCRIPTION
I think it is much nicer to have `: ` in the question for user input. Now we have:

```console
$ keep-a-changelog config -g
Please select the provider (Default: github)
  [0] github
  [1] gitlab
 > 0
Please enter the personal token for the provider (Empty to skip)f4my-private-token-super-secret0
Please enter the custom domain for the provider, if any (Empty to skip)
Created config file "/home/.keep-a-changelog/config.ini".
```

and with the change we have:

```console
$ keep-a-changelog config -g
Please select the provider (Default: github)
  [0] github
  [1] gitlab
 > 0
Please enter the personal token for the provider (Empty to skip): f4my-private-token-super-secret0
Please enter the custom domain for the provider, if any (Empty to skip): 
Created config file "/home/.keep-a-changelog/config.ini".
```