### PR TITLE
General fixes / improvements

### DIFF
--- a/src/AddEntry.php
+++ b/src/AddEntry.php
@@ -126,7 +126,7 @@ class AddEntry
     private function formatEntry(string $entry, bool $withExtraLine = false) : string
     {
         $entry = sprintf('- %s', $entry);
-        $entry = preg_replace("/\n(?!\s{2}|$)/s", "\n  ", $entry);
+        $entry = preg_replace("/\n(?!\s{2}|$)/", "\n  ", $entry);
         if ("\n" !== $entry[-1]) {
             // All entries need to end with a new line.
             $entry .= "\n";

--- a/src/BumpCommand.php
+++ b/src/BumpCommand.php
@@ -50,7 +50,7 @@ EOH;
 
     public function __construct(string $type, string $name = null)
     {
-        if (! in_array($type, array_keys($this->bumpMethods), true)) {
+        if (! isset($this->bumpMethods[$type])) {
             throw Exception\InvalidBumpTypeException::forType($type);
         }
 

--- a/src/ChangelogBump.php
+++ b/src/ChangelogBump.php
@@ -91,8 +91,6 @@ EOT;
 
     /**
      * Update the CHANGELOG with the new version information.
-     *
-     * @param string $version
      */
     public function updateChangelog(string $version)
     {

--- a/src/ChangelogEditorTrait.php
+++ b/src/ChangelogEditorTrait.php
@@ -42,7 +42,7 @@ trait ChangelogEditorTrait
         $boundaryRegex = '/^## \d+\.\d+\.\d+/';
 
         $regex = $version
-            ? sprintf('/^## %s/', preg_quote($version))
+            ? sprintf('/^## %s/', preg_quote($version, '/'))
             : $boundaryRegex;
 
         foreach ($contents as $index => $line) {

--- a/src/ChangelogEditorTrait.php
+++ b/src/ChangelogEditorTrait.php
@@ -26,7 +26,7 @@ trait ChangelogEditorTrait
      * - length, the number of lines in the contents
      * - contents, a string representing the changelog entry found in its entierty
      */
-    private function getChangelogEntry($filename, ?string $version = null) : ?stdClass
+    private function getChangelogEntry(string $filename, ?string $version = null) : ?stdClass
     {
         $contents = file($filename);
         if (false === $contents) {
@@ -68,7 +68,7 @@ trait ChangelogEditorTrait
         return $data->index !== null ? $data : null;
     }
 
-    private function updateChangelogEntry(string $filename, string $replacement, int $index, int $length)
+    private function updateChangelogEntry(string $filename, string $replacement, int $index, int $length) : void
     {
         $contents = file($filename);
         array_splice($contents, $index, $length, $replacement);

--- a/src/ChangelogFormatter.php
+++ b/src/ChangelogFormatter.php
@@ -15,7 +15,7 @@ class ChangelogFormatter
     {
         return preg_replace_callback(
             '/^\#\#\# (?<heading>Added|Changed|Deprecated|Removed|Fixed)/m',
-            function (array $matches) {
+            static function (array $matches) {
                 return sprintf(
                     "%s\n%s",
                     $matches['heading'],

--- a/src/ChangelogParser.php
+++ b/src/ChangelogParser.php
@@ -22,7 +22,7 @@ class ChangelogParser
         $fh = fopen($changelogFile, 'r');
         $regex = sprintf(
             '/^%s %s - %s$/i',
-            preg_quote('##'),
+            preg_quote('##', '/'),
             '(?P<version>\d+\.\d+\.\d+(?:(?:alpha|a|beta|b|rc|dev)\d+)?)',
             '(?P<date>(\d{4}-\d{2}-\d{2}|TBD))'
         );
@@ -43,7 +43,7 @@ class ChangelogParser
 
     public function findReleaseDateForVersion(string $changelog, string $version) : string
     {
-        $regex = preg_quote('## ' . $version);
+        $regex = preg_quote('## ' . $version, '/');
         if (! preg_match('/^' . $regex . '/m', $changelog)) {
             throw Exception\ChangelogNotFoundException::forVersion($version);
         }
@@ -58,7 +58,7 @@ class ChangelogParser
 
     public function findChangelogForVersion(string $changelog, string $version) : string
     {
-        $regex = preg_quote('## ' . $version);
+        $regex = preg_quote('## ' . $version, '/');
         if (! preg_match('/^' . $regex . '/m', $changelog)) {
             throw Exception\ChangelogNotFoundException::forVersion($version);
         }

--- a/src/ChangelogParser.php
+++ b/src/ChangelogParser.php
@@ -19,7 +19,7 @@ class ChangelogParser
      */
     public function findAllVersions(string $changelogFile) : iterable
     {
-        $fh = fopen($changelogFile, 'r');
+        $fh = fopen($changelogFile, 'rb');
         $regex = sprintf(
             '/^%s %s - %s$/i',
             preg_quote('##', '/'),

--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,7 +32,7 @@ EOH;
     /**
      * Used for testing, to allow mocking the question helper.
      *
-     * @var ?HelperInterface
+     * @var null|QuestionHelper
      */
     private $questionHelper;
 
@@ -87,7 +87,7 @@ EOH;
         return 0;
     }
 
-    private function getQuestionHelper() : HelperInterface
+    private function getQuestionHelper() : QuestionHelper
     {
         if ($this->questionHelper) {
             return $this->questionHelper;

--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -59,7 +59,7 @@ EOH;
         $overwrite = $input->getOption('overwrite') ?: false;
         $configFile = $this->getConfigFile($input);
 
-        if (file_exists($configFile) && ! $overwrite) {
+        if (! $overwrite && file_exists($configFile)) {
             throw Exception\ConfigFileExistsException::forFile($configFile);
         }
 

--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -37,7 +37,7 @@ class InvalidProviderException extends InvalidArgumentException
     public static function forInvalidProviderDomain(string $domain) : self
     {
         return new self(sprintf(
-            'Domain "%s" is invalid, and cannot be used to with changelog providers %s',
+            'Domain "%s" is invalid',
             $domain
         ));
     }

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -59,10 +59,10 @@ trait GetConfigValuesTrait
         $provider = trim($config->provider());
 
         switch ($provider) {
-            case 'github':
+            case Config::PROVIDER_GITHUB:
                 $this->provider = (new Provider\GitHub())->withDomainName($this->getDomain($config));
                 break;
-            case 'gitlab':
+            case Config::PROVIDER_GITLAB:
                 $this->provider = (new Provider\GitLab())->withDomainName($this->getDomain($config));
                 break;
             default:

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -23,7 +23,7 @@ trait GetConfigValuesTrait
     /**
      * @var null|ProviderInterface
      */
-    private $provider = null;
+    private $provider;
 
     private function prepareConfig(
         InputInterface $input,

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -66,7 +66,7 @@ trait GetConfigValuesTrait
                 $this->provider = (new Provider\GitLab())->withDomainName($this->getDomain($config));
                 break;
             default:
-                throw Exception\InvalidProviderException::forProvider($provider);
+                throw Exception\InvalidProviderException::forProvider($provider, Config::PROVIDERS);
                 break;
         }
 

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Phly\KeepAChangelog;
 
+use Phly\KeepAChangelog\Provider\ProviderInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -20,7 +21,7 @@ trait GetConfigValuesTrait
     use ConfigFileTrait;
 
     /**
-     * @var ?ProviderInterface
+     * @var null|ProviderInterface
      */
     private $provider = null;
 

--- a/src/GetConfigValuesTrait.php
+++ b/src/GetConfigValuesTrait.php
@@ -67,7 +67,6 @@ trait GetConfigValuesTrait
                 break;
             default:
                 throw Exception\InvalidProviderException::forProvider($provider, Config::PROVIDERS);
-                break;
         }
 
         return $this->provider;

--- a/src/NewChangelogCommand.php
+++ b/src/NewChangelogCommand.php
@@ -51,7 +51,7 @@ EOH;
         $version = $input->getOption('initial-version') ?: '0.1.0';
         $overwrite = $input->getOption('overwrite') ?: false;
 
-        if (file_exists($file) && ! $overwrite) {
+        if (! $overwrite && file_exists($file)) {
             throw Exception\ChangelogExistsException::forFile($file);
         }
 

--- a/src/ProvideCommonOptionsTrait.php
+++ b/src/ProvideCommonOptionsTrait.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait ProvideCommonOptionsTrait
 {
-    private function injectConfigBasedOptions()
+    private function injectConfigBasedOptions() : void
     {
         $this->addOption(
             'provider',

--- a/src/ProvideCommonOptionsTrait.php
+++ b/src/ProvideCommonOptionsTrait.php
@@ -9,10 +9,7 @@ declare(strict_types=1);
 
 namespace Phly\KeepAChangelog;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 
 trait ProvideCommonOptionsTrait
 {

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -67,7 +67,7 @@ class GitHub implements
      */
     public function getRepositoryUrlRegex() : string
     {
-        return '(github.com[:/](.*?)\.git)';
+        return '/(github.com[:/](.*?)\.git)/';
     }
 
     /**

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -52,7 +52,7 @@ class GitLab implements
      */
     public function getRepositoryUrlRegex() : string
     {
-        return sprintf('(%s[:/](.*?)\.git)', preg_quote($this->getDomainName()));
+        return sprintf('/(%s[:/](.*?)\.git)/', preg_quote($this->getDomainName(), '/'));
     }
 
     /**

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -250,7 +250,7 @@ EOH;
         array $remotes
     ) : ?string {
         $domain      = $this->getProviderDomain($provider);
-        $domainRegex = '#[/@.]' . preg_quote($domain) . '(:\d+:|:|/)#i';
+        $domainRegex = '#[/@.]' . preg_quote($domain, '#') . '(:\d+:|:|/)#i';
         $discovered  = [];
 
         foreach ($remotes as $line) {

--- a/src/ReleaseCommand.php
+++ b/src/ReleaseCommand.php
@@ -270,7 +270,7 @@ EOH;
                 continue;
             }
 
-            if (false === strstr($matches['url'], $package)) {
+            if (false === strpos($matches['url'], $package)) {
                 continue;
             }
 

--- a/test/RemoveTest.php
+++ b/test/RemoveTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveTest extends TestCase
 {
-    /** @var ?string */
+    /** @var null|string */
     private $filename;
 
     public function setUp()


### PR DESCRIPTION
Hi @weierophinney !

I've prepared this PR with some general fixes / improvements. 
Please see that there is one commit which is BC break. Probably we can solve that another way, but I want you to have a look and decide how you want to resolve it. 

There are also other issue I haven't fixed: in exceptions `InvalidPullRequestException` and `NoMatchingChangelogDiscoveredException` we have defined methods with name `for, but `for` is PHP restricted keyword and it cannot be used to define method:

> You cannot use any of the following words as constants, class names, function or method names.
> https://www.php.net/manual/en/reserved.keywords.php

Somehow we are not getting any issues, but I think it should be changed "just in case".

Each commit is small and described changed I've made.