### PR TITLE
fix: ensure tag name is used when pushing release to provider

### DIFF
--- a/src/Version/PushReleaseToProviderListener.php
+++ b/src/Version/PushReleaseToProviderListener.php
@@ -28,7 +28,7 @@ class PushReleaseToProviderListener
         try {
             $release = $provider->createRelease(
                 $releaseName,
-                $event->version(),
+                $event->tagName(),
                 $event->changelog()
             );
         } catch (Throwable $e) {

--- a/test/Version/PushReleaseToProviderListenerTest.php
+++ b/test/Version/PushReleaseToProviderListenerTest.php
@@ -47,6 +47,7 @@ class PushReleaseToProviderListenerTest extends TestCase
             )
             ->willThrow($e);
         $this->event->errorCreatingRelease($e)->shouldBeCalled();
+        $this->event->tagName()->willReturn('1.2.3')->shouldBeCalled();
 
         $listener = new PushReleaseToProviderListener();
 
@@ -66,6 +67,7 @@ class PushReleaseToProviderListenerTest extends TestCase
             )
             ->willReturn(null);
         $this->event->unexpectedProviderResult()->shouldBeCalled();
+        $this->event->tagName()->willReturn('1.2.3')->shouldBeCalled();
 
         $listener = new PushReleaseToProviderListener();
 
@@ -85,6 +87,7 @@ class PushReleaseToProviderListenerTest extends TestCase
             )
             ->willReturn('url-to-release');
         $this->event->releaseCreated('url-to-release')->shouldBeCalled();
+        $this->event->tagName()->willReturn('1.2.3')->shouldBeCalled();
 
         $listener = new PushReleaseToProviderListener();
 


### PR DESCRIPTION
The second argument to ProviderInterface::createRelease is `$tagName`,
but I was incorrectly using the version. If the tag name option is not
present, this will default to the version, but otherwise, the provider
will not be able to find the tag to associate with the release.
