### PR TITLE
fix: choice questions return index, not value

### DIFF
--- a/src/Config/PromptForGitRemoteListener.php
+++ b/src/Config/PromptForGitRemoteListener.php
@@ -31,11 +31,11 @@ class PromptForGitRemoteListener
 
         $remote = $helper->ask($event->input(), $event->output(), $question);
 
-        if ('Abort release' === $remote) {
+        if ('abort' === $remote) {
             $event->abort();
             return;
         }
 
-        $event->foundRemote($remote);
+        $event->foundRemote($choices[$remote]);
     }
 }

--- a/test/Config/PromptForGitRemoteListenerTest.php
+++ b/test/Config/PromptForGitRemoteListenerTest.php
@@ -58,7 +58,7 @@ class PromptForGitRemoteListenerTest extends TestCase
                 $this->output,
                 Argument::type(ChoiceQuestion::class)
             )
-            ->willReturn('Abort release');
+            ->willReturn('abort');
 
         $listener = new PromptForGitRemoteListener();
 
@@ -82,7 +82,7 @@ class PromptForGitRemoteListenerTest extends TestCase
                 $this->output,
                 Argument::type(ChoiceQuestion::class)
             )
-            ->willReturn('origin');
+            ->willReturn(0);
 
         $listener = new PromptForGitRemoteListener();
 


### PR DESCRIPTION
When you ask a `ChoiceQuestion`, the result returned is the _index_ of
the choice requested, not the _value_. As such, we need to grab the
value via the index in order to use it.

Fixes #58