### PR TITLE
qa: update to PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json
 /docs/html/

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "captainhook/plugin-composer": "^4.0",
-        "phpunit/phpunit": "^7.4",
+        "phpunit/phpunit": "^8.4.3",
         "webimpress/coding-standard": "dev-master@dev",
         "zendframework/zend-coding-standard": "2.0.0-alpha.3@alpha || ^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -383,35 +383,34 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.5.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
-                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0.0",
-                "php": "^7.3.0"
+                "php": "^7.1.0"
             },
             "require-dev": {
-                "composer/composer": "^1.8.6",
-                "doctrine/coding-standard": "^6.0.0",
+                "composer/composer": "^1.6.3",
+                "doctrine/coding-standard": "^5.0.1",
                 "ext-zip": "*",
-                "infection/infection": "^0.13.4",
-                "phpunit/phpunit": "^8.2.5",
-                "vimeo/psalm": "^3.4.9"
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.5.17"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "PackageVersions\\Installer",
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -430,7 +429,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-07-17T15:49:50+00:00"
+            "time": "2019-11-15T16:17:10+00:00"
         },
         {
             "name": "php-http/cache-plugin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50a363148e9092b38b62c3ec0073cf10",
+    "content-hash": "8fabddefea973190558d3529dea2d071",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -60,27 +60,28 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.3.3",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+                "reference": "0895c932405407fd3a7368b6910c09a24d26db11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0895c932405407fd3a7368b6910c09a24d26db11",
+                "reference": "0895c932405407fd3a7368b6910c09a24d26db11",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
+                "guzzlehttp/psr7": "^1.6.1",
                 "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1.1"
             },
             "suggest": {
                 "psr/log": "Required for using the Log middleware"
@@ -92,12 +93,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -121,7 +122,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2018-04-22T15:46:56+00:00"
+            "time": "2019-10-23T15:58:00+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -176,33 +177,37 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.5.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
                 "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5"
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
+                "ext-zlib": "*",
                 "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -239,43 +244,43 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-12-04T20:46:45+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "knplabs/github-api",
-            "version": "2.11.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
-                "reference": "7e67b4ccf9ef62fbd6321a314c61d3202c07b855"
+                "reference": "2665eb80831054d403464c922c9935741af90dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/7e67b4ccf9ef62fbd6321a314c61d3202c07b855",
-                "reference": "7e67b4ccf9ef62fbd6321a314c61d3202c07b855",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/2665eb80831054d403464c922c9935741af90dc6",
+                "reference": "2665eb80831054d403464c922c9935741af90dc6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
                 "php-http/cache-plugin": "^1.4",
-                "php-http/client-common": "^1.6",
+                "php-http/client-common": "^1.6 || ^2.0",
                 "php-http/client-implementation": "^1.0",
                 "php-http/discovery": "^1.0",
-                "php-http/httplug": "^1.1",
+                "php-http/httplug": "^1.1 || ^2.0",
                 "psr/cache": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
                 "cache/array-adapter": "^0.4",
                 "guzzlehttp/psr7": "^1.2",
-                "php-http/guzzle6-adapter": "^1.0",
-                "php-http/mock-client": "^1.0",
-                "phpunit/phpunit": "^5.5 || ^6.0"
+                "php-http/guzzle6-adapter": "^1.0 || ^2.0",
+                "php-http/mock-client": "^1.2",
+                "phpunit/phpunit": "^7.0 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.11.x-dev"
+                    "dev-master": "2.12.x-dev"
                 }
             },
             "autoload": {
@@ -289,13 +294,13 @@
             ],
             "authors": [
                 {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                },
+                {
                     "name": "Thibault Duplessis",
                     "email": "thibault.duplessis@gmail.com",
                     "homepage": "http://ornicar.github.com"
-                },
-                {
-                    "name": "KnpLabs Team",
-                    "homepage": "http://knplabs.com"
                 }
             ],
             "description": "GitHub API v3 client",
@@ -306,42 +311,42 @@
                 "gist",
                 "github"
             ],
-            "time": "2019-01-28T19:31:35+00:00"
+            "time": "2019-11-07T17:18:26+00:00"
         },
         {
             "name": "m4tthumphrey/php-gitlab-api",
-            "version": "9.13.0",
+            "version": "9.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/m4tthumphrey/php-gitlab-api.git",
-                "reference": "35c1719c9b0a87a14c76ebe7c540d7d07cdfff9e"
+                "reference": "0b2fc89046bc0cecb1a72728dc6767a28e32705c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/m4tthumphrey/php-gitlab-api/zipball/35c1719c9b0a87a14c76ebe7c540d7d07cdfff9e",
-                "reference": "35c1719c9b0a87a14c76ebe7c540d7d07cdfff9e",
+                "url": "https://api.github.com/repos/m4tthumphrey/php-gitlab-api/zipball/0b2fc89046bc0cecb1a72728dc6767a28e32705c",
+                "reference": "0b2fc89046bc0cecb1a72728dc6767a28e32705c",
                 "shasum": ""
             },
             "require": {
                 "ext-xml": "*",
                 "php": "^5.6 || ^7.0",
-                "php-http/client-common": "^1.6",
+                "php-http/client-common": "^1.6 || ^2.0",
                 "php-http/client-implementation": "^1.0",
                 "php-http/discovery": "^1.2",
-                "php-http/httplug": "^1.1",
+                "php-http/httplug": "^1.1 || ^2.0",
                 "php-http/multipart-stream-builder": "^1.0",
-                "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0"
+                "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^1.2",
-                "php-http/guzzle6-adapter": "^1.0",
-                "php-http/mock-client": "^1.0",
+                "php-http/guzzle6-adapter": "^1.0 || ^2.0",
+                "php-http/mock-client": "^1.2",
                 "phpunit/phpunit": "^5.7.27 || ^6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.12.x-dev"
+                    "dev-master": "9.14-dev"
                 }
             },
             "autoload": {
@@ -355,17 +360,17 @@
             ],
             "authors": [
                 {
-                    "name": "Thibault Duplessis",
-                    "email": "thibault.duplessis@gmail.com",
-                    "homepage": "http://ornicar.github.com"
+                    "name": "Matt Humphrey",
+                    "homepage": "http://m4tt.io"
                 },
                 {
                     "name": "KnpLabs Team",
                     "homepage": "http://knplabs.com"
                 },
                 {
-                    "name": "Matt Humphrey",
-                    "homepage": "http://m4tt.io"
+                    "name": "Thibault Duplessis",
+                    "email": "thibault.duplessis@gmail.com",
+                    "homepage": "http://ornicar.github.com"
                 }
             ],
             "description": "GitLab API client",
@@ -374,38 +379,39 @@
                 "api",
                 "gitlab"
             ],
-            "time": "2019-04-15T07:38:13+00:00"
+            "time": "2019-11-26T11:19:29+00:00"
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
+                "php": "^7.3.0"
             },
             "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
+                "composer/composer": "^1.8.6",
+                "doctrine/coding-standard": "^6.0.0",
                 "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.0.0"
+                "infection/infection": "^0.13.4",
+                "phpunit/phpunit": "^8.2.5",
+                "vimeo/psalm": "^3.4.9"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "PackageVersions\\Installer",
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -424,7 +430,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-02-21T12:16:21+00:00"
+            "time": "2019-07-17T15:49:50+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -484,16 +490,16 @@
         },
         {
             "name": "php-http/client-common",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/client-common.git",
-                "reference": "0e156a12cc3e46f590c73bf57592a2252fc3dc48"
+                "reference": "c0390ae3c8f2ae9d50901feef0127fb9e396f6b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/client-common/zipball/0e156a12cc3e46f590c73bf57592a2252fc3dc48",
-                "reference": "0e156a12cc3e46f590c73bf57592a2252fc3dc48",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/c0390ae3c8f2ae9d50901feef0127fb9e396f6b4",
+                "reference": "c0390ae3c8f2ae9d50901feef0127fb9e396f6b4",
                 "shasum": ""
             },
             "require": {
@@ -501,7 +507,7 @@
                 "php-http/httplug": "^1.1",
                 "php-http/message": "^1.6",
                 "php-http/message-factory": "^1.0",
-                "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0"
+                "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^1.4",
@@ -515,7 +521,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -541,32 +547,33 @@
                 "http",
                 "httplug"
             ],
-            "time": "2019-02-02T07:03:15+00:00"
+            "time": "2019-11-18T08:54:36+00:00"
         },
         {
             "name": "php-http/discovery",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "684855f2c2e9d0a61868b8f8d6bd0295c8a4b651"
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/684855f2c2e9d0a61868b8f8d6bd0295c8a4b651",
-                "reference": "684855f2c2e9d0a61868b8f8d6bd0295c8a4b651",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/e822f86a6983790aa17ab13aa7e69631e86806b6",
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^7.1"
             },
             "conflict": {
                 "nyholm/psr7": "<1.0"
             },
             "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^4.0",
                 "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0",
-                "phpspec/phpspec": "^2.4",
+                "phpspec/phpspec": "^5.1",
                 "puli/composer-plugin": "1.0.0-beta10"
             },
             "suggest": {
@@ -576,7 +583,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -605,7 +612,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2019-02-23T07:42:53+00:00"
+            "time": "2019-06-30T09:04:27+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",
@@ -725,21 +732,21 @@
         },
         {
             "name": "php-http/message",
-            "version": "1.7.2",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "b159ffe570dffd335e22ef0b91a946eacb182fa1"
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/b159ffe570dffd335e22ef0b91a946eacb182fa1",
-                "reference": "b159ffe570dffd335e22ef0b91a946eacb182fa1",
+                "url": "https://api.github.com/repos/php-http/message/zipball/ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
                 "shasum": ""
             },
             "require": {
                 "clue/stream-filter": "^1.4",
-                "php": "^5.4 || ^7.0",
+                "php": "^7.1",
                 "php-http/message-factory": "^1.0.2",
                 "psr/http-message": "^1.0"
             },
@@ -765,7 +772,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -793,7 +800,7 @@
                 "message",
                 "psr-7"
             ],
-            "time": "2018-11-01T09:32:41+00:00"
+            "time": "2019-08-05T06:55:08+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -847,33 +854,34 @@
         },
         {
             "name": "php-http/multipart-stream-builder",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/multipart-stream-builder.git",
-                "reference": "1fa3c623fc813a43b39494b2a1612174e36e0fb0"
+                "reference": "5d73adad53cf1d674dcc6c5b288a3ff3f76c4849"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/1fa3c623fc813a43b39494b2a1612174e36e0fb0",
-                "reference": "1fa3c623fc813a43b39494b2a1612174e36e0fb0",
+                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/5d73adad53cf1d674dcc6c5b288a3ff3f76c4849",
+                "reference": "5d73adad53cf1d674dcc6c5b288a3ff3f76c4849",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "php-http/discovery": "^1.0",
+                "php": "^7.1",
+                "php-http/discovery": "^1.7",
                 "php-http/message-factory": "^1.0.2",
+                "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
+                "nyholm/psr7": "^1.0",
                 "php-http/message": "^1.5",
-                "phpunit/phpunit": "^4.8 || ^5.4",
-                "zendframework/zend-diactoros": "^1.3.5"
+                "phpunit/phpunit": "^7.5 || ^8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.3-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -900,7 +908,7 @@
                 "multipart stream",
                 "stream"
             ],
-            "time": "2017-05-21T17:45:25+00:00"
+            "time": "2019-08-22T14:13:19+00:00"
         },
         {
             "name": "php-http/promise",
@@ -1094,6 +1102,58 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -1145,24 +1205,24 @@
         },
         {
             "name": "ralouphie/getallheaders",
-            "version": "2.0.5",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7.0",
-                "satooshi/php-coveralls": ">=1.0"
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
             },
             "type": "library",
             "autoload": {
@@ -1181,7 +1241,7 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11T07:05:27+00:00"
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "symfony/console",
@@ -1261,16 +1321,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.3.0",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "914e0edcb7cd0c9f494bc023b1d47534f4542332"
+                "reference": "2be23e63f33de16b49294ea6581f462932a77e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/914e0edcb7cd0c9f494bc023b1d47534f4542332",
-                "reference": "914e0edcb7cd0c9f494bc023b1d47534f4542332",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2be23e63f33de16b49294ea6581f462932a77e2f",
+                "reference": "2be23e63f33de16b49294ea6581f462932a77e2f",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1339,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -1311,7 +1371,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-05-10T05:38:46+00:00"
+            "time": "2019-10-28T21:57:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1492,23 +1552,24 @@
     "packages-dev": [
         {
             "name": "captainhook/captainhook",
-            "version": "4.3.0",
+            "version": "4.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CaptainHookPhp/captainhook.git",
-                "reference": "6545c7a932d55e08601b0ec5e9f38e9eb32321a6"
+                "reference": "b89ee9e6b445f44173b2a2a142513d597f490244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CaptainHookPhp/captainhook/zipball/6545c7a932d55e08601b0ec5e9f38e9eb32321a6",
-                "reference": "6545c7a932d55e08601b0ec5e9f38e9eb32321a6",
+                "url": "https://api.github.com/repos/CaptainHookPhp/captainhook/zipball/b89ee9e6b445f44173b2a2a142513d597f490244",
+                "reference": "b89ee9e6b445f44173b2a2a142513d597f490244",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "ext-spl": "*",
-                "php": ">=7.1.0",
+                "php": "^7.1",
+                "sebastianfeldmann/camino": "^0.9.1",
                 "sebastianfeldmann/cli": "^3.0",
                 "sebastianfeldmann/git": "^2.2",
                 "symfony/console": ">=2.7"
@@ -1518,6 +1579,7 @@
             },
             "require-dev": {
                 "composer/composer": "~1",
+                "mikey179/vfsstream": "~1",
                 "phpunit/phpunit": "^7.0"
             },
             "bin": [
@@ -1557,7 +1619,7 @@
                 "pre-push",
                 "prepare-commit-msg"
             ],
-            "time": "2019-05-20T10:30:51+00:00"
+            "time": "2019-12-02T15:20:27+00:00"
         },
         {
             "name": "captainhook/plugin-composer",
@@ -1678,16 +1740,16 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -1730,20 +1792,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.1",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
                 "shasum": ""
             },
             "require": {
@@ -1778,7 +1840,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2019-08-09T12:45:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1884,35 +1946,33 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1934,30 +1994,30 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
+                "doctrine/instantiator": "^1.0.5",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.4"
             },
@@ -1985,41 +2045,40 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2019-09-12T14:27:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2032,26 +2091,27 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
                 "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -2066,8 +2126,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2095,44 +2155,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-10-03T11:07:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2158,7 +2218,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2253,16 +2313,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -2298,20 +2358,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20T10:12:59+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
@@ -2324,7 +2384,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2347,49 +2407,48 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-10-30T05:52:18+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.12",
+            "version": "8.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c"
+                "reference": "67f9e35bffc0dd52d55d565ddbe4230454fd6a4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
-                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/67f9e35bffc0dd52d55d565ddbe4230454fd6a4e",
+                "reference": "67f9e35bffc0dd52d55d565ddbe4230454fd6a4e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
@@ -2397,7 +2456,7 @@
             "suggest": {
                 "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2405,7 +2464,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "8.4-dev"
                 }
             },
             "autoload": {
@@ -2431,7 +2490,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-05-28T11:59:40+00:00"
+            "time": "2019-11-06T09:42:23+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2600,16 +2659,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.2",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
@@ -2649,20 +2708,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-05-05T09:05:15+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
@@ -2690,6 +2749,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -2698,16 +2761,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -2716,27 +2775,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2744,7 +2806,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2767,7 +2829,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2957,6 +3019,52 @@
             "time": "2018-10-04T04:07:39+00:00"
         },
         {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
+        },
+        {
             "name": "sebastian/version",
             "version": "2.0.1",
             "source": {
@@ -3000,17 +3108,17 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "sebastianfeldmann/cli",
-            "version": "3.1.0",
+            "name": "sebastianfeldmann/camino",
+            "version": "0.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianfeldmann/cli.git",
-                "reference": "0944887eb147879bd148bd987a68e57c3a92c40f"
+                "url": "https://github.com/sebastianfeldmann/camino.git",
+                "reference": "0a9cedfde3e5e38eb650158047b58514de8183ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianfeldmann/cli/zipball/0944887eb147879bd148bd987a68e57c3a92c40f",
-                "reference": "0944887eb147879bd148bd987a68e57c3a92c40f",
+                "url": "https://api.github.com/repos/sebastianfeldmann/camino/zipball/0a9cedfde3e5e38eb650158047b58514de8183ab",
+                "reference": "0a9cedfde3e5e38eb650158047b58514de8183ab",
                 "shasum": ""
             },
             "require": {
@@ -3018,6 +3126,56 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Camino\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "Path management the OO way",
+            "homepage": "https://github.com/sebastianfeldmann/camino",
+            "keywords": [
+                "file system",
+                "path"
+            ],
+            "time": "2019-11-15T16:07:20+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/cli",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/cli.git",
+                "reference": "a20e8560fd4f21bac193a65f8678a7d1b3932e08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/cli/zipball/a20e8560fd4f21bac193a65f8678a7d1b3932e08",
+                "reference": "a20e8560fd4f21bac193a65f8678a7d1b3932e08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^4.3"
             },
             "type": "library",
             "autoload": {
@@ -3040,25 +3198,25 @@
             "keywords": [
                 "cli"
             ],
-            "time": "2019-04-12T08:40:18+00:00"
+            "time": "2019-10-29T13:48:15+00:00"
         },
         {
             "name": "sebastianfeldmann/git",
-            "version": "2.2.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianfeldmann/git.git",
-                "reference": "3acae632b2d588e45ff5434e243e9119cb2b1897"
+                "reference": "d52744f4e24e2ad4aef49c303b8397af0b1dffed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianfeldmann/git/zipball/3acae632b2d588e45ff5434e243e9119cb2b1897",
-                "reference": "3acae632b2d588e45ff5434e243e9119cb2b1897",
+                "url": "https://api.github.com/repos/sebastianfeldmann/git/zipball/d52744f4e24e2ad4aef49c303b8397af0b1dffed",
+                "reference": "d52744f4e24e2ad4aef49c303b8397af0b1dffed",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.1",
+                "php": "^7.1",
                 "sebastianfeldmann/cli": "^3.0.0"
             },
             "require-dev": {
@@ -3067,7 +3225,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -3090,7 +3248,7 @@
             "keywords": [
                 "git"
             ],
-            "time": "2019-04-11T09:35:13+00:00"
+            "time": "2019-09-30T15:04:34+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3133,16 +3291,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
                 "shasum": ""
             },
             "require": {
@@ -3180,20 +3338,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2019-10-28T04:36:32+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -3205,7 +3363,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -3222,12 +3380,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -3238,20 +3396,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -3278,7 +3436,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-04-04T09:56:43+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -3286,12 +3444,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "5df57b6f69a7cd147982d615a01642bd6c4049f8"
+                "reference": "ece265467a883370ab75746c4318b5d47c010ab7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/5df57b6f69a7cd147982d615a01642bd6c4049f8",
-                "reference": "5df57b6f69a7cd147982d615a01642bd6c4049f8",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/ece265467a883370ab75746c4318b5d47c010ab7",
+                "reference": "ece265467a883370ab75746c4318b5d47c010ab7",
                 "shasum": ""
             },
             "require": {
@@ -3323,36 +3481,33 @@
                 "psr-12",
                 "webimpress"
             ],
-            "time": "2019-05-28T20:25:02+00:00"
+            "time": "2019-11-13T22:29:56+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -3374,7 +3529,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",

--- a/test/Bump/BumpChangelogVersionEventTest.php
+++ b/test/Bump/BumpChangelogVersionEventTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BumpChangelogVersionEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class)->reveal();
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Bump/BumpChangelogVersionListenerTest.php
+++ b/test/Bump/BumpChangelogVersionListenerTest.php
@@ -25,7 +25,7 @@ class BumpChangelogVersionListenerTest extends TestCase
     /** @var string */
     private $tempFile;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tempFile = tempnam(sys_get_temp_dir(), 'KAC');
         file_put_contents(
@@ -40,7 +40,7 @@ class BumpChangelogVersionListenerTest extends TestCase
         $this->event->config()->will([$this->config, 'reveal']);
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         unlink($this->tempFile);
     }

--- a/test/Bump/BumpCommandTest.php
+++ b/test/Bump/BumpCommandTest.php
@@ -23,7 +23,7 @@ class BumpCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Bump/BumpToVersionCommandTest.php
+++ b/test/Bump/BumpToVersionCommandTest.php
@@ -22,7 +22,7 @@ class BumpToVersionCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Bump/ChangelogBumpTest.php
+++ b/test/Bump/ChangelogBumpTest.php
@@ -26,7 +26,7 @@ class ChangelogBumpTest extends TestCase
     /** @var string */
     private $tempFile;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tempFile = tempnam(sys_get_temp_dir(), 'KAC');
         file_put_contents(
@@ -36,7 +36,7 @@ class ChangelogBumpTest extends TestCase
         $this->bumper = new ChangelogBump($this->tempFile);
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         unlink($this->tempFile);
     }

--- a/test/Changelog/CreateNewChangelogEventTest.php
+++ b/test/Changelog/CreateNewChangelogEventTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateNewChangelogEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config     = $this->prophesize(Config::class);
         $this->dispatcher = $this->prophesize(EventDispatcherInterface::class)->reveal();

--- a/test/Changelog/CreateNewChangelogListenerTest.php
+++ b/test/Changelog/CreateNewChangelogListenerTest.php
@@ -27,7 +27,7 @@ class CreateNewChangelogListenerTest extends TestCase
     /** @var null|string */
     private $tempFile;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn = function () {
         };
@@ -41,7 +41,7 @@ class CreateNewChangelogListenerTest extends TestCase
         $this->event->createdChangelog()->will($voidReturn);
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if ($this->tempFile) {
             if (file_exists($this->tempFile)) {

--- a/test/Changelog/EditChangelogLinksEventTest.php
+++ b/test/Changelog/EditChangelogLinksEventTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EditChangelogLinksEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Changelog/EditChangelogLinksListenerTest.php
+++ b/test/Changelog/EditChangelogLinksListenerTest.php
@@ -23,7 +23,7 @@ use function file_get_contents;
 
 class EditChangelogLinksListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn            = function () {
         };

--- a/test/Changelog/EditLinksCommandTest.php
+++ b/test/Changelog/EditLinksCommandTest.php
@@ -22,7 +22,7 @@ class EditLinksCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Changelog/FindChangelogLinksListenerTest.php
+++ b/test/Changelog/FindChangelogLinksListenerTest.php
@@ -16,7 +16,7 @@ use Prophecy\Argument;
 
 class FindChangelogLinksListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn = function () {
         };

--- a/test/Changelog/NewCommandTest.php
+++ b/test/Changelog/NewCommandTest.php
@@ -25,7 +25,7 @@ class NewCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Common/ChangelogEditorTest.php
+++ b/test/Common/ChangelogEditorTest.php
@@ -26,12 +26,12 @@ class ChangelogEditorTest extends TestCase
     /** @var null|string */
     private $tempFile;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tempFile = null;
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if ($this->tempFile && file_exists($this->tempFile)) {
             unlink($this->tempFile);

--- a/test/Common/ChangelogEntryTest.php
+++ b/test/Common/ChangelogEntryTest.php
@@ -16,7 +16,7 @@ use UnexpectedValueException;
 
 class ChangelogEntryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->entry = new ChangelogEntry();
     }

--- a/test/Common/ChangelogParserTest.php
+++ b/test/Common/ChangelogParserTest.php
@@ -20,7 +20,7 @@ use function iterator_to_array;
 
 class ChangelogParserTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->changelog = file_get_contents(__DIR__ . '/../_files/CHANGELOG.md');
         $this->parser    = new ChangelogParser();

--- a/test/Common/DiscoverChangelogEntryListenerTest.php
+++ b/test/Common/DiscoverChangelogEntryListenerTest.php
@@ -17,7 +17,7 @@ use Prophecy\Argument;
 
 class DiscoverChangelogEntryListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn = function () {
         };

--- a/test/Common/DiscoverEditorListenerTest.php
+++ b/test/Common/DiscoverEditorListenerTest.php
@@ -26,7 +26,7 @@ class DiscoverEditorListenerTest extends TestCase
     /** @var array */
     private $serverSuperGlobal = [];
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->serverSuperGlobal = $_SERVER;
         $this->editorEnvValue    = getenv('EDITOR');
@@ -35,7 +35,7 @@ class DiscoverEditorListenerTest extends TestCase
         };
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         $_SERVER = $this->serverSuperGlobal;
         $this->editorEnvValue

--- a/test/Common/EditorTest.php
+++ b/test/Common/EditorTest.php
@@ -20,7 +20,7 @@ use const STDOUT;
 
 class EditorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->output = $this->prophesize(OutputInterface::class);
     }

--- a/test/Common/IsChangelogReadableListenerTest.php
+++ b/test/Common/IsChangelogReadableListenerTest.php
@@ -19,7 +19,7 @@ use function realpath;
 
 class IsChangelogReadableListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config = $this->prophesize(Config::class);
         $this->event  = $this->prophesize(ReleaseEvent::class);

--- a/test/Common/ParseChangelogListenerTest.php
+++ b/test/Common/ParseChangelogListenerTest.php
@@ -20,7 +20,7 @@ use function realpath;
 
 class ParseChangelogListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config = $this->prophesize(Config::class);
         $this->event  = $this->prophesize(ChangelogAwareEventInterface::class);

--- a/test/Common/ValidateVersionListenerTest.php
+++ b/test/Common/ValidateVersionListenerTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidateVersionListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->event = $this->prophesize(VersionAwareEventInterface::class);
     }

--- a/test/Config/AbstractDiscoverPackageFromFileListenerTest.php
+++ b/test/Config/AbstractDiscoverPackageFromFileListenerTest.php
@@ -18,7 +18,7 @@ abstract class AbstractDiscoverPackageFromFileListenerTest extends TestCase
 {
     abstract public function createListener() : AbstractDiscoverPackageFromFileListener;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->event = $this->prophesize(PackageNameDiscovery::class);
     }

--- a/test/Config/ConfigListenerTest.php
+++ b/test/Config/ConfigListenerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config    = new Config();
         $this->discovery = $this->prophesize(ConfigDiscovery::class);

--- a/test/Config/DiscoverPackageFromGitRemoteListenerTest.php
+++ b/test/Config/DiscoverPackageFromGitRemoteListenerTest.php
@@ -20,7 +20,7 @@ use function preg_match;
 
 class DiscoverPackageFromGitRemoteListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->provider = $this->prophesize(ProviderSpec::class);
         $this->config   = $this->prophesize(Config::class);

--- a/test/Config/DiscoverRemoteFromGitRemotesListenerTest.php
+++ b/test/Config/DiscoverRemoteFromGitRemotesListenerTest.php
@@ -16,7 +16,7 @@ use Prophecy\Argument;
 
 class DiscoverRemoteFromGitRemotesListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->provider = $this->prophesize(ProviderSpec::class);
         $this->config   = $this->prophesize(Config::class);

--- a/test/Config/PackageNameDiscoveryTest.php
+++ b/test/Config/PackageNameDiscoveryTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PackageNameDiscoveryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config = new Config();
         $this->input  = $this->prophesize(InputInterface::class);

--- a/test/Config/PromptForGitRemoteListenerTest.php
+++ b/test/Config/PromptForGitRemoteListenerTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class PromptForGitRemoteListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class)->reveal();
         $this->output = $this->prophesize(OutputInterface::class)->reveal();

--- a/test/Config/RemoteNameDiscoveryTest.php
+++ b/test/Config/RemoteNameDiscoveryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoteNameDiscoveryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->helper = $this->prophesize(QuestionHelper::class)->reveal();
         $this->input  = $this->prophesize(InputInterface::class)->reveal();

--- a/test/Config/RetrieveGlobalConfigListenerTest.php
+++ b/test/Config/RetrieveGlobalConfigListenerTest.php
@@ -17,7 +17,7 @@ use function realpath;
 
 class RetrieveGlobalConfigListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config = new Config();
         $this->event  = $this->prophesize(ConfigDiscovery::class);

--- a/test/Config/RetrieveInputOptionsListenerTest.php
+++ b/test/Config/RetrieveInputOptionsListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetrieveInputOptionsListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/AbstractCreateConfigListenerTestCase.php
+++ b/test/ConfigCommand/AbstractCreateConfigListenerTestCase.php
@@ -51,13 +51,13 @@ abstract class AbstractCreateConfigListenerTestCase extends TestCase
 
     abstract public function configureEventToSkipCreate(ObjectProphecy $event) : void;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->existingConfigFile = null;
         $this->tempConfigFile     = null;
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         $this->existingConfigFile = null;
         if ($this->tempConfigFile && file_exists($this->tempConfigFile)) {

--- a/test/ConfigCommand/AbstractEditConfigListenerTestCase.php
+++ b/test/ConfigCommand/AbstractEditConfigListenerTestCase.php
@@ -27,7 +27,7 @@ abstract class AbstractEditConfigListenerTestCase extends TestCase
 
     abstract public function configureEventToSkipEdit(ObjectProphecy $event) : void;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->voidReturn = function () {
         };

--- a/test/ConfigCommand/AbstractRemoveConfigListenerTestCase.php
+++ b/test/ConfigCommand/AbstractRemoveConfigListenerTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractRemoveConfigListenerTestCase extends TestCase
 
     abstract public function configureEventToSkipRemove(ObjectProphecy $event) : void;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->voidReturn = function () {
         };

--- a/test/ConfigCommand/AbstractShowConfigListenerTestCase.php
+++ b/test/ConfigCommand/AbstractShowConfigListenerTestCase.php
@@ -32,7 +32,7 @@ abstract class AbstractShowConfigListenerTestCase extends TestCase
 
     abstract public function configureEventToSkipShow(ObjectProphecy $event) : void;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->voidReturn = function () {
         };

--- a/test/ConfigCommand/CreateCommandTest.php
+++ b/test/ConfigCommand/CreateCommandTest.php
@@ -22,7 +22,7 @@ class CreateCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/CreateConfigEventTest.php
+++ b/test/ConfigCommand/CreateConfigEventTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateConfigEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/EditCommandTest.php
+++ b/test/ConfigCommand/EditCommandTest.php
@@ -22,7 +22,7 @@ class EditCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/EditConfigEventTest.php
+++ b/test/ConfigCommand/EditConfigEventTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EditConfigEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/RemoveCommandTest.php
+++ b/test/ConfigCommand/RemoveCommandTest.php
@@ -22,7 +22,7 @@ class RemoveCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/RemoveConfigEventTest.php
+++ b/test/ConfigCommand/RemoveConfigEventTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveConfigEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/RemoveGlobalConfigListenerTest.php
+++ b/test/ConfigCommand/RemoveGlobalConfigListenerTest.php
@@ -74,13 +74,13 @@ class RemoveGlobalConfigListenerTest extends AbstractRemoveConfigListenerTestCas
         $event->removeGlobal()->willReturn(false);
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tempFile = null;
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if ($this->tempFile && file_exists($this->tempFile)) {
             unlink($this->tempFile);

--- a/test/ConfigCommand/RemoveLocalConfigListenerTest.php
+++ b/test/ConfigCommand/RemoveLocalConfigListenerTest.php
@@ -74,13 +74,13 @@ class RemoveLocalConfigListenerTest extends AbstractRemoveConfigListenerTestCase
         $event->removeLocal()->willReturn(false);
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tempFile = null;
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if ($this->tempFile && file_exists($this->tempFile)) {
             unlink($this->tempFile);

--- a/test/ConfigCommand/ShowCommandTest.php
+++ b/test/ConfigCommand/ShowCommandTest.php
@@ -22,7 +22,7 @@ class ShowCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/ShowConfigEventTest.php
+++ b/test/ConfigCommand/ShowConfigEventTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowConfigEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/ConfigCommand/ShowMergedConfigListenerTest.php
+++ b/test/ConfigCommand/ShowMergedConfigListenerTest.php
@@ -18,7 +18,7 @@ use function parse_ini_string;
 
 class ShowMergedConfigListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn = function () {
         };

--- a/test/Entry/AbstractPrependLinkListenerTestCase.php
+++ b/test/Entry/AbstractPrependLinkListenerTestCase.php
@@ -78,7 +78,7 @@ abstract class AbstractPrependLinkListenerTestCase extends TestCase
      */
     abstract public function reportInvalidLinkRequested(ObjectProphecy $event) : void;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->identifier   = null;
         $this->link         = null;

--- a/test/Entry/AddChangelogEntryEventTest.php
+++ b/test/Entry/AddChangelogEntryEventTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AddChangelogEntryEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Entry/AddChangelogEntryListenerTest.php
+++ b/test/Entry/AddChangelogEntryListenerTest.php
@@ -70,7 +70,7 @@ EOC;
 
 EOC;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->entry  = new ChangelogEntry();
         $this->config = $this->prophesize(Config::class);

--- a/test/Entry/EntryCommandTest.php
+++ b/test/Entry/EntryCommandTest.php
@@ -23,7 +23,7 @@ use TypeError;
 
 class EntryCommandTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
         $this->input      = $this->prophesize(InputInterface::class);

--- a/test/Entry/IsEntryArgumentEmptyListenerTest.php
+++ b/test/Entry/IsEntryArgumentEmptyListenerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class IsEntryArgumentEmptyListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->event = $this->prophesize(AddChangelogEntryEvent::class);
         $this->event->entryIsEmpty()->will(function () {

--- a/test/Provider/GitHubTest.php
+++ b/test/Provider/GitHubTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class GitHubTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->github = new GitHub();
     }

--- a/test/Provider/GitLabTest.php
+++ b/test/Provider/GitLabTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class GitLabTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->gitlab = new GitLab();
     }

--- a/test/Version/CreateReleaseNameListenerTest.php
+++ b/test/Version/CreateReleaseNameListenerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class CreateReleaseNameListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input  = $this->prophesize(InputInterface::class);
         $this->config = $this->prophesize(Config::class);

--- a/test/Version/EditChangelogVersionEventTest.php
+++ b/test/Version/EditChangelogVersionEventTest.php
@@ -23,7 +23,7 @@ use function sprintf;
 
 class EditChangelogVersionEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config     = $this->prophesize(Config::class);
         $this->input      = $this->prophesize(InputInterface::class);

--- a/test/Version/EditChangelogVersionListenerTest.php
+++ b/test/Version/EditChangelogVersionListenerTest.php
@@ -23,7 +23,7 @@ use function file_get_contents;
 
 class EditChangelogVersionListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->voidReturn      = function () {
         };

--- a/test/Version/EditCommandTest.php
+++ b/test/Version/EditCommandTest.php
@@ -22,7 +22,7 @@ class EditCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/ListCommandTest.php
+++ b/test/Version/ListCommandTest.php
@@ -22,7 +22,7 @@ class ListCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/ListVersionsEventTest.php
+++ b/test/Version/ListVersionsEventTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListVersionsEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/PromptForRemovalConfirmationListenerTest.php
+++ b/test/Version/PromptForRemovalConfirmationListenerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class PromptForRemovalConfirmationListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->entry  = new ChangelogEntry();
         $this->input  = $this->prophesize(InputInterface::class);

--- a/test/Version/PushReleaseToProviderListenerTest.php
+++ b/test/Version/PushReleaseToProviderListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PushReleaseToProviderListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->output   = $this->prophesize(OutputInterface::class);
         $this->event    = $this->prophesize(ReleaseEvent::class);

--- a/test/Version/PushTagToRemoteListenerTest.php
+++ b/test/Version/PushTagToRemoteListenerTest.php
@@ -20,7 +20,7 @@ use function sprintf;
 
 class PushTagToRemoteListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config = new Config();
         $this->output = $this->prophesize(OutputInterface::class);

--- a/test/Version/ReadyCommandTest.php
+++ b/test/Version/ReadyCommandTest.php
@@ -26,7 +26,7 @@ class ReadyCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/ReadyLatestChangelogEventTest.php
+++ b/test/Version/ReadyLatestChangelogEventTest.php
@@ -20,7 +20,7 @@ use function sprintf;
 
 class ReadyLatestChangelogEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->dispatcher = $this->prophesize(EventDispatcherInterface::class)->reveal();
         $this->input      = $this->prophesize(InputInterface::class)->reveal();

--- a/test/Version/ReleaseCommandTest.php
+++ b/test/Version/ReleaseCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ReleaseCommandTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/ReleaseEventTest.php
+++ b/test/Version/ReleaseEventTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ReleaseEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/RemoveChangelogVersionEventTest.php
+++ b/test/Version/RemoveChangelogVersionEventTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveChangelogVersionEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config     = $this->prophesize(Config::class);
         $this->input      = $this->prophesize(InputInterface::class);

--- a/test/Version/RemoveChangelogVersionListenerTest.php
+++ b/test/Version/RemoveChangelogVersionListenerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class RemoveChangelogVersionListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->entry  = new ChangelogEntry();
         $this->config = $this->prophesize(Config::class);

--- a/test/Version/RemoveCommandTest.php
+++ b/test/Version/RemoveCommandTest.php
@@ -22,7 +22,7 @@ class RemoveCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/SetDateForChangelogReleaseListenerTest.php
+++ b/test/Version/SetDateForChangelogReleaseListenerTest.php
@@ -49,7 +49,7 @@ class SetDateForChangelogReleaseListenerTest extends TestCase
 
 EOC;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $voidReturn   = function () {
         };

--- a/test/Version/ShowCommandTest.php
+++ b/test/Version/ShowCommandTest.php
@@ -22,7 +22,7 @@ class ShowCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/ShowVersionEventTest.php
+++ b/test/Version/ShowVersionEventTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowVersionEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/TagCommandTest.php
+++ b/test/Version/TagCommandTest.php
@@ -22,7 +22,7 @@ class TagCommandTest extends TestCase
 {
     use ExecuteCommandTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->input      = $this->prophesize(InputInterface::class);
         $this->output     = $this->prophesize(OutputInterface::class);

--- a/test/Version/TagReleaseEventTest.php
+++ b/test/Version/TagReleaseEventTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TagReleaseEventTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->config     = $this->prophesize(Config::class);
         $this->input      = $this->prophesize(InputInterface::class);

--- a/test/Version/VerifyTagExistsListenerTest.php
+++ b/test/Version/VerifyTagExistsListenerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class VerifyTagExistsListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->event = $this->prophesize(ReleaseEvent::class);
         $this->event


### PR DESCRIPTION
As only PHP 7.2+ is supported we can use just PHPUnit 8.

Based on #63 so this should be merged first.

All changes here are done automatically by using:
https://github.com/webimpress/phpunit-migration :) 