### PR TITLE
Prefer semantic versioning term patch in bump command

### DIFF
--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -37,9 +37,9 @@ $application->getDefinition()
     ]);
 
 $application->addCommands([
-    new Bump\BumpCommand(Bump\BumpCommand::BUMP_BUGFIX, $dispatcher, 'bump'),
-    new Bump\BumpCommand(Bump\BumpCommand::BUMP_BUGFIX, $dispatcher, 'bump:bugfix'),
-    new Bump\BumpCommand(Bump\BumpCommand::BUMP_BUGFIX, $dispatcher, 'bump:patch'),
+    new Bump\BumpCommand(Bump\BumpCommand::BUMP_PATCH, $dispatcher, 'bump'),
+    new Bump\BumpCommand(Bump\BumpCommand::BUMP_PATCH, $dispatcher, 'bump:bugfix'),
+    new Bump\BumpCommand(Bump\BumpCommand::BUMP_PATCH, $dispatcher, 'bump:patch'),
     new Bump\BumpCommand(Bump\BumpCommand::BUMP_MINOR, $dispatcher, 'bump:minor'),
     new Bump\BumpCommand(Bump\BumpCommand::BUMP_MAJOR, $dispatcher, 'bump:major'),
     new Bump\BumpToVersionCommand($dispatcher, 'bump:to-version'),

--- a/src/Bump/BumpCommand.php
+++ b/src/Bump/BumpCommand.php
@@ -20,15 +20,15 @@ use function sprintf;
 /**
  * Bump a changelog version.
  *
- * Bumps a changelog to the next bugfix, minor, or major version, based
+ * Bumps a changelog to the next major, minor or patch version, based
  * on how the command is configured at initialization.
  */
 class BumpCommand extends Command
 {
-    public const BUMP_BUGFIX = 'bugfix';
     public const BUMP_MAJOR  = 'major';
     public const BUMP_MINOR  = 'minor';
-    public const BUMP_PATCH  = self::BUMP_BUGFIX;
+    public const BUMP_PATCH  = 'patch';
+    public const BUMP_BUGFIX = self::BUMP_PATCH;
 
     private const DESC_TEMPLATE = 'Create a new changelog entry for the next %s release.';
 
@@ -42,9 +42,9 @@ EOH;
 
     /** @var string[] */
     private $bumpMethods = [
-        self::BUMP_BUGFIX => 'bumpBugfixVersion',
-        self::BUMP_MAJOR  => 'bumpMajorVersion',
-        self::BUMP_MINOR  => 'bumpMinorVersion',
+        self::BUMP_MAJOR => 'bumpMajorVersion',
+        self::BUMP_MINOR => 'bumpMinorVersion',
+        self::BUMP_PATCH => 'bumpPatchVersion',
     ];
 
     /** @var EventDispatcherInterface */
@@ -72,10 +72,14 @@ EOH;
 
     protected function configure() : void
     {
-        $this->setDescription(sprintf(
-            self::DESC_TEMPLATE,
-            $this->type
-        ));
+        if ($this->type === 'bugfix') {
+            $this->setDescription('Alias for bump:patch.');
+        } else {
+            $this->setDescription(sprintf(
+                self::DESC_TEMPLATE,
+                $this->type
+            ));
+        }
 
         $this->setHelp(sprintf(
             self::HELP_TEMPLATE,

--- a/src/Bump/ChangelogBump.php
+++ b/src/Bump/ChangelogBump.php
@@ -72,7 +72,7 @@ EOT;
         return $matches['version'];
     }
 
-    public function bumpBugfixVersion(string $version) : string
+    public function bumpPatchVersion(string $version) : string
     {
         [$major, $minor, $bugfix] = $this->parseVersion($version);
         $bugfix                   = (int) $bugfix;

--- a/test/Bump/BumpChangelogVersionListenerTest.php
+++ b/test/Bump/BumpChangelogVersionListenerTest.php
@@ -57,7 +57,7 @@ class BumpChangelogVersionListenerTest extends TestCase
 
     public function bumpMethods() : iterable
     {
-        yield 'bugfix' => ['bumpBugfixVersion', '2.0.1'];
+        yield 'bugfix' => ['bumpPatchVersion', '2.0.1'];
         yield 'minor'  => ['bumpMinorVersion', '2.1.0'];
         yield 'major'  => ['bumpMajorVersion', '3.0.0'];
     }

--- a/test/Bump/BumpCommandTest.php
+++ b/test/Bump/BumpCommandTest.php
@@ -38,10 +38,10 @@ class BumpCommandTest extends TestCase
 
     public function expectedTypes() : iterable
     {
-        yield 'BUMP_BUGFIX' => [BumpCommand::BUMP_BUGFIX, 'bumpBugfixVersion'];
         yield 'BUMP_MAJOR'  => [BumpCommand::BUMP_MAJOR, 'bumpMajorVersion'];
         yield 'BUMP_MINOR'  => [BumpCommand::BUMP_MINOR, 'bumpMinorVersion'];
-        yield 'BUMP_PATCH'  => [BumpCommand::BUMP_PATCH, 'bumpBugfixVersion'];
+        yield 'BUMP_PATCH'  => [BumpCommand::BUMP_PATCH, 'bumpPatchVersion'];
+        yield 'BUMP_BUGFIX' => [BumpCommand::BUMP_BUGFIX, 'bumpPatchVersion'];
     }
 
     /**

--- a/test/Bump/ChangelogBumpTest.php
+++ b/test/Bump/ChangelogBumpTest.php
@@ -63,7 +63,7 @@ class ChangelogBumpTest extends TestCase
      */
     public function testBumpsBugfixVersionCorrectly(string $version, string $expected)
     {
-        $this->assertEquals($expected, $this->bumper->bumpBugfixVersion($version));
+        $this->assertEquals($expected, $this->bumper->bumpPatchVersion($version));
     }
 
     public function minorVersions() : array


### PR DESCRIPTION
This makes it clear that bump:bugfix is just an alias for the
bump:patch command, which aligns closely to the semantic versioning
standard.
