### PR TITLE
Feature: semver 2.0

### DIFF
--- a/src/Common/ValidateVersionListener.php
+++ b/src/Common/ValidateVersionListener.php
@@ -16,7 +16,7 @@ class ValidateVersionListener
     public function __invoke(VersionAwareEventInterface $event) : void
     {
         $version = $event->version() ?: '';
-        if (! preg_match('/^\d+\.\d+\.\d+((?:alpha|a|beta|b|rc|dev|patch|pl|p)\d+)?$/i', $version)) {
+        if (! preg_match('/^\d+\.\d+\.\d+(-?(?:alpha|a|beta|b|rc|dev|patch|pl|p)\.?\d+)?$/i', $version)) {
             $event->versionIsInvalid($version);
             return;
         }

--- a/src/Common/ValidateVersionListener.php
+++ b/src/Common/ValidateVersionListener.php
@@ -10,13 +10,17 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\Common;
 
 use function preg_match;
+use function sprintf;
 
 class ValidateVersionListener
 {
+    public const PRE_RELEASE_REGEX = '-?(?:alpha|a|beta|b|rc|dev|patch|pl|p)\.?\d+';
+
     public function __invoke(VersionAwareEventInterface $event) : void
     {
         $version = $event->version() ?: '';
-        if (! preg_match('/^\d+\.\d+\.\d+(-?(?:alpha|a|beta|b|rc|dev|patch|pl|p)\.?\d+)?$/i', $version)) {
+        $pattern = sprintf('/^\d+\.\d+\.\d+(%s)?$/i', self::PRE_RELEASE_REGEX);
+        if (! preg_match($pattern, $version)) {
             $event->versionIsInvalid($version);
             return;
         }

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -11,6 +11,7 @@ namespace Phly\KeepAChangelog\Provider;
 
 use Github\Client as GitHubClient;
 use Github\Exception\ExceptionInterface as GithubException;
+use Phly\KeepAChangelog\Common\ValidateVersionListener;
 
 use function explode;
 use function filter_var;
@@ -22,7 +23,8 @@ use const FILTER_VALIDATE_URL;
 
 class GitHub implements ProviderInterface
 {
-    private const DEFAULT_URL = 'https://api.github.com';
+    private const DEFAULT_URL       = 'https://api.github.com';
+    private const PRE_RELEASE_REGEX = ValidateVersionListener::PRE_RELEASE_REGEX;
 
     /**
      * Use for testing purposes only.
@@ -196,7 +198,8 @@ class GitHub implements ProviderInterface
 
     private function isVersionPrelease(string $version) : bool
     {
-        if (preg_match('/(alpha|a|beta|b|rc|dev)\d+$/i', $version)) {
+        $pattern = sprintf('/%s$/i', self::PRE_RELEASE_REGEX);
+        if (preg_match($pattern, $version)) {
             return true;
         }
         return false;

--- a/test/Common/ValidateVersionListenerTest.php
+++ b/test/Common/ValidateVersionListenerTest.php
@@ -30,51 +30,51 @@ class ValidateVersionListenerTest extends TestCase
 
     public function versions() : iterable
     {
-        yield 'major-only'          => ['1', $isFailure = true];
-        yield 'minor-only'          => ['1.1', $isFailure = true];
-        yield 'malformed'           => ['1.1.1abcde', $isFailure = true];
+        yield 'major-only'              => ['1', $isFailure = true];
+        yield 'minor-only'              => ['1.1', $isFailure = true];
+        yield 'malformed'               => ['1.1.1abcde', $isFailure = true];
 
-        yield 'bugfix'              => ['1.1.1', $isFailure = false];
-        yield 'minor'               => ['1.2.0', $isFailure = false];
-        yield 'major'               => ['2.0.0', $isFailure = false];
+        yield 'bugfix'                  => ['1.1.1', $isFailure = false];
+        yield 'minor'                   => ['1.2.0', $isFailure = false];
+        yield 'major'                   => ['2.0.0', $isFailure = false];
 
-        yield 'alpha-wrong'         => ['2.0.0alphaBeta', $isFailure = true];
-        yield 'alpha-long'          => ['2.0.0alpha1', $isFailure = false];
-        yield 'alpha-short'         => ['2.0.0a1', $isFailure = false];
-        yield 'alpha-long-uc'       => ['2.0.0ALPHA1', $isFailure = false];
-        yield 'alpha-short-uc'      => ['2.0.0A1', $isFailure = false];
-        yield 'alpha-long-dash'     => ['2.0.0-alpha1', $isFailure = false];
-        yield 'alpha-long-dash-dot' => ['2.0.0-alpha.4', $isFailure = false];
+        yield 'alpha-wrong'             => ['2.0.0alphaBeta', $isFailure = true];
+        yield 'alpha-long'              => ['2.0.0alpha1', $isFailure = false];
+        yield 'alpha-short'             => ['2.0.0a1', $isFailure = false];
+        yield 'alpha-long-uc'           => ['2.0.0ALPHA1', $isFailure = false];
+        yield 'alpha-short-uc'          => ['2.0.0A1', $isFailure = false];
+        yield 'alpha-long-hyphen'       => ['2.0.0-alpha1', $isFailure = false];
+        yield 'alpha-long-hyphen-dot'   => ['2.0.0-alpha.4', $isFailure = false];
 
-        yield 'beta-wrong'          => ['2.0.0betaRC', $isFailure = true];
-        yield 'beta-long'           => ['2.0.0beta2', $isFailure = false];
-        yield 'beta-short'          => ['2.0.0b2', $isFailure = false];
-        yield 'beta-long-uc'        => ['2.0.0BETA2', $isFailure = false];
-        yield 'beta-short-uc'       => ['2.0.0B2', $isFailure = false];
-        yield 'beta-long-dash'      => ['2.0.0-beta2', $isFailure = false];
-        yield 'beta-long-dash-dot'  => ['2.0.0-beta.4', $isFailure = false];
+        yield 'beta-wrong'              => ['2.0.0betaRC', $isFailure = true];
+        yield 'beta-long'               => ['2.0.0beta2', $isFailure = false];
+        yield 'beta-short'              => ['2.0.0b2', $isFailure = false];
+        yield 'beta-long-uc'            => ['2.0.0BETA2', $isFailure = false];
+        yield 'beta-short-uc'           => ['2.0.0B2', $isFailure = false];
+        yield 'beta-long-hyphen'        => ['2.0.0-beta2', $isFailure = false];
+        yield 'beta-long-hyphen-dot'    => ['2.0.0-beta.4', $isFailure = false];
 
-        yield 'rc-wrong'            => ['2.0.0rcDEV', $isFailure = true];
-        yield 'rc-long'             => ['2.0.0rc3', $isFailure = false];
-        yield 'rc-long-uc'          => ['2.0.0RC3', $isFailure = false];
-        yield 'rc-long-dash'        => ['2.0.0-rc3', $isFailure = false];
-        yield 'rc-long-dash-dot'    => ['2.0.0-rc.3', $isFailure = false];
+        yield 'rc-wrong'                => ['2.0.0rcDEV', $isFailure = true];
+        yield 'rc-long'                 => ['2.0.0rc3', $isFailure = false];
+        yield 'rc-long-uc'              => ['2.0.0RC3', $isFailure = false];
+        yield 'rc-long-hyphen'          => ['2.0.0-rc3', $isFailure = false];
+        yield 'rc-long-hyphen-dot'      => ['2.0.0-rc.3', $isFailure = false];
 
-        yield 'dev-wrong'           => ['2.0.0devPATCH', $isFailure = true];
-        yield 'dev-long'            => ['2.0.0dev4', $isFailure = false];
-        yield 'dev-long-uc'         => ['2.0.0DEV4', $isFailure = false];
-        yield 'dev-long-dash'       => ['2.0.0-dev4', $isFailure = false];
-        yield 'dev-long-dash-dot'   => ['2.0.0-dev.4', $isFailure = false];
+        yield 'dev-wrong'               => ['2.0.0devPATCH', $isFailure = true];
+        yield 'dev-long'                => ['2.0.0dev4', $isFailure = false];
+        yield 'dev-long-uc'             => ['2.0.0DEV4', $isFailure = false];
+        yield 'dev-long-hyphen'         => ['2.0.0-dev4', $isFailure = false];
+        yield 'dev-long-hyphen-dot'     => ['2.0.0-dev.4', $isFailure = false];
 
-        yield 'patch-wrong'         => ['2.0.0patchFOO', $isFailure = true];
-        yield 'patch-long'          => ['2.0.0patch5', $isFailure = false];
-        yield 'patch-short'         => ['2.0.0pl5', $isFailure = false];
-        yield 'patch-shorter'       => ['2.0.0p5', $isFailure = false];
-        yield 'patch-long-uc'       => ['2.0.0PATCH5', $isFailure = false];
-        yield 'patch-short-uc'      => ['2.0.0PL5', $isFailure = false];
-        yield 'patch-shorter-uc'    => ['2.0.0P5', $isFailure = false];
-        yield 'patch-long-dash'     => ['2.0.0-patch4', $isFailure = false];
-        yield 'patch-long-dash-dot' => ['2.0.0-patch.4', $isFailure = false];
+        yield 'patch-wrong'             => ['2.0.0patchFOO', $isFailure = true];
+        yield 'patch-long'              => ['2.0.0patch5', $isFailure = false];
+        yield 'patch-short'             => ['2.0.0pl5', $isFailure = false];
+        yield 'patch-shorter'           => ['2.0.0p5', $isFailure = false];
+        yield 'patch-long-uc'           => ['2.0.0PATCH5', $isFailure = false];
+        yield 'patch-short-uc'          => ['2.0.0PL5', $isFailure = false];
+        yield 'patch-shorter-uc'        => ['2.0.0P5', $isFailure = false];
+        yield 'patch-long-hyphen'       => ['2.0.0-patch4', $isFailure = false];
+        yield 'patch-long-hyphen-dot'   => ['2.0.0-patch.4', $isFailure = false];
     }
 
     /**

--- a/test/Common/ValidateVersionListenerTest.php
+++ b/test/Common/ValidateVersionListenerTest.php
@@ -30,41 +30,51 @@ class ValidateVersionListenerTest extends TestCase
 
     public function versions() : iterable
     {
-        yield 'major-only'     => ['1', $isFailure = true];
-        yield 'minor-only'     => ['1.1', $isFailure = true];
-        yield 'malformed'      => ['1.1.1abcde', $isFailure = true];
+        yield 'major-only'          => ['1', $isFailure = true];
+        yield 'minor-only'          => ['1.1', $isFailure = true];
+        yield 'malformed'           => ['1.1.1abcde', $isFailure = true];
 
-        yield 'bugfix'         => ['1.1.1', $isFailure = false];
-        yield 'minor'          => ['1.2.0', $isFailure = false];
-        yield 'major'          => ['2.0.0', $isFailure = false];
+        yield 'bugfix'              => ['1.1.1', $isFailure = false];
+        yield 'minor'               => ['1.2.0', $isFailure = false];
+        yield 'major'               => ['2.0.0', $isFailure = false];
 
-        yield 'alpha-wrong'    => ['2.0.0alphaBeta', $isFailure = true];
-        yield 'alpha-long'     => ['2.0.0alpha1', $isFailure = false];
-        yield 'alpha-short'    => ['2.0.0a1', $isFailure = false];
-        yield 'alpha-long-uc'  => ['2.0.0ALPHA1', $isFailure = false];
-        yield 'alpha-short-uc' => ['2.0.0A1', $isFailure = false];
+        yield 'alpha-wrong'         => ['2.0.0alphaBeta', $isFailure = true];
+        yield 'alpha-long'          => ['2.0.0alpha1', $isFailure = false];
+        yield 'alpha-short'         => ['2.0.0a1', $isFailure = false];
+        yield 'alpha-long-uc'       => ['2.0.0ALPHA1', $isFailure = false];
+        yield 'alpha-short-uc'      => ['2.0.0A1', $isFailure = false];
+        yield 'alpha-long-dash'     => ['2.0.0-alpha1', $isFailure = false];
+        yield 'alpha-long-dash-dot' => ['2.0.0-alpha.4', $isFailure = false];
 
-        yield 'beta-wrong'     => ['2.0.0betaRC', $isFailure = true];
-        yield 'beta-long'      => ['2.0.0beta2', $isFailure = false];
-        yield 'beta-short'     => ['2.0.0b2', $isFailure = false];
-        yield 'beta-long-uc'   => ['2.0.0BETA2', $isFailure = false];
-        yield 'beta-short-uc'  => ['2.0.0B2', $isFailure = false];
+        yield 'beta-wrong'          => ['2.0.0betaRC', $isFailure = true];
+        yield 'beta-long'           => ['2.0.0beta2', $isFailure = false];
+        yield 'beta-short'          => ['2.0.0b2', $isFailure = false];
+        yield 'beta-long-uc'        => ['2.0.0BETA2', $isFailure = false];
+        yield 'beta-short-uc'       => ['2.0.0B2', $isFailure = false];
+        yield 'beta-long-dash'      => ['2.0.0-beta2', $isFailure = false];
+        yield 'beta-long-dash-dot'  => ['2.0.0-beta.4', $isFailure = false];
 
-        yield 'rc-wrong'       => ['2.0.0rcDEV', $isFailure = true];
-        yield 'rc-long'        => ['2.0.0rc3', $isFailure = false];
-        yield 'rc-long-uc'     => ['2.0.0RC3', $isFailure = false];
+        yield 'rc-wrong'            => ['2.0.0rcDEV', $isFailure = true];
+        yield 'rc-long'             => ['2.0.0rc3', $isFailure = false];
+        yield 'rc-long-uc'          => ['2.0.0RC3', $isFailure = false];
+        yield 'rc-long-dash'        => ['2.0.0-rc3', $isFailure = false];
+        yield 'rc-long-dash-dot'    => ['2.0.0-rc.3', $isFailure = false];
 
-        yield 'dev-wrong'      => ['2.0.0devPATCH', $isFailure = true];
-        yield 'dev-long'       => ['2.0.0dev4', $isFailure = false];
-        yield 'dev-long-uc'    => ['2.0.0DEV4', $isFailure = false];
+        yield 'dev-wrong'           => ['2.0.0devPATCH', $isFailure = true];
+        yield 'dev-long'            => ['2.0.0dev4', $isFailure = false];
+        yield 'dev-long-uc'         => ['2.0.0DEV4', $isFailure = false];
+        yield 'dev-long-dash'       => ['2.0.0-dev4', $isFailure = false];
+        yield 'dev-long-dash-dot'   => ['2.0.0-dev.4', $isFailure = false];
 
-        yield 'patch-wrong'    => ['2.0.0patchFOO', $isFailure = true];
-        yield 'patch-long'     => ['2.0.0patch5', $isFailure = false];
-        yield 'patch-short'    => ['2.0.0pl5', $isFailure = false];
-        yield 'patch-shorter'  => ['2.0.0p5', $isFailure = false];
-        yield 'patch-long-uc'  => ['2.0.0PATCH5', $isFailure = false];
-        yield 'patch-short-uc' => ['2.0.0PL5', $isFailure = false];
-        yield 'patch-shorter-uc' => ['2.0.0P5', $isFailure = false];
+        yield 'patch-wrong'         => ['2.0.0patchFOO', $isFailure = true];
+        yield 'patch-long'          => ['2.0.0patch5', $isFailure = false];
+        yield 'patch-short'         => ['2.0.0pl5', $isFailure = false];
+        yield 'patch-shorter'       => ['2.0.0p5', $isFailure = false];
+        yield 'patch-long-uc'       => ['2.0.0PATCH5', $isFailure = false];
+        yield 'patch-short-uc'      => ['2.0.0PL5', $isFailure = false];
+        yield 'patch-shorter-uc'    => ['2.0.0P5', $isFailure = false];
+        yield 'patch-long-dash'     => ['2.0.0-patch4', $isFailure = false];
+        yield 'patch-long-dash-dot' => ['2.0.0-patch.4', $isFailure = false];
     }
 
     /**


### PR DESCRIPTION
Hey there,

I wanted to use `keep-a-changelog` for one of my libraries to create a pre-release.
As of https://semver.org/#spec-item-9, tagging a release with `2.0.0-rc.1` is valid but `keep-a-changelog` did not accept it.

With v1.0, it probably was not allowed to tag a release with a hyphen and thus it was not supported by this library.


I also synced the pre-release regex from the `Github` provider with the `VersionValidationListener`.