### PR TITLE
Create listener that verifies we have a version associated with the release to tag

### DIFF
--- a/src/Common/ChangelogParser.php
+++ b/src/Common/ChangelogParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
  * @copyright Copyright (c) 2018 Matthew Weier O'Phinney
@@ -66,10 +67,12 @@ class ChangelogParser
     }
 
     /**
+     * @param bool $strict Set this to true to indicate that a date must be
+     *                     provided for the version (and not "TBD").
      * @throws Exception\ChangelogNotFoundException
      * @throws Exception\ChangelogMissingDateException
      */
-    public function findReleaseDateForVersion(string $changelog, string $version) : string
+    public function findReleaseDateForVersion(string $changelog, string $version, bool $strict = false) : string
     {
         $regex = sprintf(
             '%s (?:\[%2$s\]|%2$s)',
@@ -80,7 +83,10 @@ class ChangelogParser
             throw Exception\ChangelogNotFoundException::forVersion($version);
         }
 
-        $regex .= ' - (?P<date>(\d{4}-\d{2}-\d{2}|TBD))';
+        $regex .= sprintf(
+            ' - (?P<date>(\d{4}-\d{2}-\d{2}%s))',
+            $strict ? '' : '|TBD'
+        );
         if (! preg_match('/^' . $regex . '/m', $changelog, $matches)) {
             throw Exception\ChangelogMissingDateException::forVersion($version);
         }

--- a/src/ListenerProvider.php
+++ b/src/ListenerProvider.php
@@ -127,6 +127,7 @@ class ListenerProvider implements ListenerProviderInterface
             Common\ValidateVersionListener::class,
             Common\IsChangelogReadableListener::class,
             Common\ParseChangelogListener::class,
+            Version\VerifyVersionHasReleaseDateListener::class,
             Common\FormatChangelogListener::class,
             Version\TagReleaseListener::class,
         ],

--- a/src/Version/VerifyVersionHasReleaseDateListener.php
+++ b/src/Version/VerifyVersionHasReleaseDateListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Common\ChangelogParser;
+use Phly\KeepAChangelog\Exception\ChangelogMissingDateException;
+
+use function sprintf;
+
+class VerifyVersionHasReleaseDateListener
+{
+    public function __invoke(TagReleaseEvent $event) : void
+    {
+        $parser = new ChangelogParser();
+
+        try {
+            $parser->findReleaseDateForVersion(
+                $event->changelog(),
+                $event->version(),
+                true
+            );
+        } catch (ChangelogMissingDateException $e) {
+            $event->taggingFailed();
+            $event->output()->writeln(sprintf(
+                '<error>Version %s does not have a release date associated with it!</error>',
+                $event->version()
+            ));
+            $event->output()->writeln('<error>You may need to run version:ready first</error>');
+        }
+    }
+}

--- a/test/Version/VerifyVersionHasReleaseDateListenerTest.php
+++ b/test/Version/VerifyVersionHasReleaseDateListenerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Version\TagReleaseEvent;
+use Phly\KeepAChangelog\Version\VerifyVersionHasReleaseDateListener;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VerifyVersionHasReleaseDateListenerTest extends TestCase
+{
+    public function testDoesNothingIfChangelogHasAssociatedReleaseDate() : void
+    {
+        $version   = '1.2.3';
+        $changelog = <<<'END'
+## 1.2.3 - 2020-07-15
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Fixed
+
+- Something.
+END;
+        /** @var TagReleaseEvent|ObjectProphecy $event */
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->changelog()->willReturn($changelog)->shouldBeCalled();
+        $event->version()->willReturn($version)->shouldBeCalledTimes(1);
+        $event->taggingFailed()->shouldNotBeCalled();
+        $event->output()->shouldNotBeCalled();
+
+        $listener = new VerifyVersionHasReleaseDateListener();
+        $this->assertNull($listener($event->reveal()));
+    }
+
+    public function testNotifiesEventTaggingFailedIfChangelogDoesNotHaveReleaseDate() : void
+    {
+        $version   = '1.2.3';
+        $changelog = <<<'END'
+## 1.2.3 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Fixed
+
+- Something.
+END;
+
+        /** @var OutputInterface|ObjectProphecy $event */
+        $output = $this->prophesize(OutputInterface::class);
+        $output
+            ->writeln(Argument::containingString('Version 1.2.3 does not have a release date'))
+            ->shouldBeCalled();
+        $output
+            ->writeln(Argument::containingString('version:ready'))
+            ->shouldBeCalled();
+
+        /** @var TagReleaseEvent|ObjectProphecy $event */
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->changelog()->willReturn($changelog)->shouldBeCalled();
+        $event->version()->willReturn($version)->shouldBeCalled();
+        $event->taggingFailed()->shouldBeCalled();
+        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+
+        $listener = new VerifyVersionHasReleaseDateListener();
+        $this->assertNull($listener($event->reveal()));
+    }
+}


### PR DESCRIPTION
Per a request in #60, this patch provides functionality for verifying that the version to tag has an associated release date in the CHANGELOG file, aborting if it does not.

Details:

- Adds a new optional argument to `ChangelogParser::findChangelogForVersion()`, `bool $strict = false`.  When `true`, it will omit `TBD` as a valid release date, and thus raise an exception.
- Creates `VerifyVersionHasReleaseDateListener`, which listens to the `TagReleaseEvent`, and checks to see if the changelog includes the release date. If not, it notifies the event that tagging has failed, and sends output detailing what changes are necessary.
- Adds the new listener in the `TagReleaseEvent` listeners, after the listener that parses the changelog, but before the one that formats it for the tag.