### PR TITLE
Check for local changes before tagging

### DIFF
--- a/src/ListenerProvider.php
+++ b/src/ListenerProvider.php
@@ -124,6 +124,7 @@ class ListenerProvider implements ListenerProviderInterface
         ],
         Version\TagReleaseEvent::class             => [
             Version\TagCommandConfigListener::class,
+            Version\CheckTreeForChangesListener::class,
             Common\ValidateVersionListener::class,
             Common\IsChangelogReadableListener::class,
             Common\ParseChangelogListener::class,

--- a/src/Version/CheckTreeForChangesListener.php
+++ b/src/Version/CheckTreeForChangesListener.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Version;
+
+use function count;
+
+class CheckTreeForChangesListener
+{
+    /**
+     * exec()
+     *
+     * This property exists for testing purposes only. The signature is:
+     *
+     * <code>
+     * function(string $command[, array &$output[, int &$return]])
+     * </code>
+     *
+     * @var callable
+     */
+    public $exec = 'exec';
+
+    public function __invoke(TagReleaseEvent $event) : void
+    {
+        if ($event->input()->getOption('force')) {
+            return;
+        }
+
+        $command = 'git status -s';
+        $output  = [];
+        $status  = 0;
+        $exec    = $this->exec;
+
+        $exec($command, $output, $status);
+
+        if ($status !== 0 || count($output) > 0) {
+            $event->taggingFailed();
+            $event->output()->write('<error>You have changes present in your tree that are not checked in.</error>');
+            $event->output()->write('Either check them in, or use the --force flag.');
+        }
+    }
+}

--- a/src/Version/TagCommand.php
+++ b/src/Version/TagCommand.php
@@ -62,6 +62,13 @@ EOH;
             'Alternate git tag name to use when tagging; defaults to <version>'
         );
 
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Force tagging even if there are changes present in your tree'
+        );
+
         $this->injectPackageOption($this);
     }
 

--- a/test/Version/CheckTreeForChangesListenerTest.php
+++ b/test/Version/CheckTreeForChangesListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Version\CheckTreeForChangesListener;
+use Phly\KeepAChangelog\Version\TagReleaseEvent;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckTreeForChangesListenerTest extends TestCase
+{
+    public function testListenerDoesNothingIfForceFlagIsPresent() : void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->getOption('force')->willReturn(true)->shouldBeCalled();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->input()->will([$input, 'reveal'])->shouldBeCalled();
+        $event->taggingFailed()->shouldNotBeCalled();
+        $event->output()->shouldNotBeCalled();
+
+        $listener = new CheckTreeForChangesListener();
+        $this->assertNull($listener($event->reveal()));
+    }
+
+    public function testListenerDoesNothingIfForceFlagNotPresentButTreeIsClean() : void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->getOption('force')->willReturn(null)->shouldBeCalled();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->input()->will([$input, 'reveal'])->shouldBeCalled();
+        $event->taggingFailed()->shouldNotBeCalled();
+        $event->output()->shouldNotBeCalled();
+
+        $listener       = new CheckTreeForChangesListener();
+        $listener->exec = function ($command, &$output, &$return) {
+            $return = 0;
+        };
+
+        $this->assertNull($listener($event->reveal()));
+    }
+
+    public function testListenerNotifesEventThatTaggingFailedIfForceFlagNotPresentAndTreeIsDirty() : void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->getOption('force')->willReturn(null)->shouldBeCalled();
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->write(Argument::containingString('not checked in'))->shouldBeCalled();
+        $output->write(Argument::containingString('use the --force'))->shouldBeCalled();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->input()->will([$input, 'reveal'])->shouldBeCalled();
+        $event->taggingFailed()->shouldBeCalled();
+        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+
+        $listener       = new CheckTreeForChangesListener();
+        $listener->exec = function ($command, &$output, &$return) {
+            $output[] = 'some output';
+            $return   = 0;
+        };
+
+        $this->assertNull($listener($event->reveal()));
+    }
+
+    public function testListenerNotifesEventThatTaggingFailedIfForceFlagNotPresentAndStatusCheckFails() : void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->getOption('force')->willReturn(null)->shouldBeCalled();
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->write(Argument::containingString('not checked in'))->shouldBeCalled();
+        $output->write(Argument::containingString('use the --force'))->shouldBeCalled();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->input()->will([$input, 'reveal'])->shouldBeCalled();
+        $event->taggingFailed()->shouldBeCalled();
+        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+
+        $listener       = new CheckTreeForChangesListener();
+        $listener->exec = function ($command, &$output, &$return) {
+            $return = 1;
+        };
+
+        $this->assertNull($listener($event->reveal()));
+    }
+}


### PR DESCRIPTION
This patch adds the `CheckTreeForChangesListener`, which checks to see if we have a clean local checkout before attempting to tag. If not, it will report the issue to the user.

Users may pass a new option, `--force` to `version:tag` in order to bypass this behavior.

See #60 for original request.