### PR TITLE
Allow creating and promoting "Unreleased" versions

### DIFF
--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -55,6 +55,7 @@ $application->addCommands([
     new Entry\EntryCommand($dispatcher, 'entry:deprecated'),
     new Entry\EntryCommand($dispatcher, 'entry:removed'),
     new Entry\EntryCommand($dispatcher, 'entry:fixed'),
+    new Unreleased\PromoteCommand($dispatcher, 'unreleased:promote'),
     new Version\EditCommand($dispatcher, 'version:edit'),
     new Version\ListCommand($dispatcher, 'version:list'),
     new Version\ReadyCommand($dispatcher, 'version:ready'),

--- a/bin/keep-a-changelog
+++ b/bin/keep-a-changelog
@@ -42,6 +42,7 @@ $application->addCommands([
     new Bump\BumpCommand(Bump\BumpCommand::BUMP_PATCH, $dispatcher, 'bump:patch'),
     new Bump\BumpCommand(Bump\BumpCommand::BUMP_MINOR, $dispatcher, 'bump:minor'),
     new Bump\BumpCommand(Bump\BumpCommand::BUMP_MAJOR, $dispatcher, 'bump:major'),
+    new Bump\BumpCommand(Bump\BumpCommand::BUMP_UNRELEASED, $dispatcher, 'unreleased:create'),
     new Bump\BumpToVersionCommand($dispatcher, 'bump:to-version'),
     new Changelog\EditLinksCommand($dispatcher, 'changelog:edit-links'),
     new Changelog\NewCommand($dispatcher, 'changelog:new'),

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,6 +146,10 @@ $ keep-a-changelog help <command>
 - `entry:deprecated`: Create a changelog entry in the "Deprecated" section.
 - `entry:removed`: Create a changelog entry in the "Removed" section.
 - `entry:fixed`: Create a changelog entry in the "Fixed" section.
+- `unreleased:create`: Create a new "Unreleased" entry at the top of thee
+  changelog file.
+- `unreleased:promote`: Rename the "Unreleased" entry with the provided version,
+  setting the release date.
 - `version:edit`: Edit a full changelog version and its entries.
 - `version:list`: List all changelog versions currently in the file.
 - `version:ready`: Mark a changelog version ready for release by setting its date.

--- a/src/Bump/BumpChangelogVersionEvent.php
+++ b/src/Bump/BumpChangelogVersionEvent.php
@@ -19,6 +19,8 @@ use function sprintf;
 
 class BumpChangelogVersionEvent extends AbstractEvent
 {
+    public const UNRELEASED = 'Unreleased';
+
     /**
      * ChangelogBump method to use when bumping version.
      *
@@ -50,6 +52,11 @@ class BumpChangelogVersionEvent extends AbstractEvent
             || ($bumpMethod && $version)
         ) {
             throw Exception\InvalidChangelogBumpCriteriaException::forCriteria($bumpMethod, $version);
+        }
+
+        if (! $version && $bumpMethod === self::UNRELEASED) {
+            $version    = self::UNRELEASED;
+            $bumpMethod = null;
         }
 
         $this->input      = $input;

--- a/src/Common/ChangelogParser.php
+++ b/src/Common/ChangelogParser.php
@@ -20,6 +20,7 @@ use function fopen;
 use function preg_match;
 use function preg_quote;
 use function sprintf;
+use function strtolower;
 
 class ChangelogParser
 {

--- a/src/Common/DiscoverChangelogEntryListener.php
+++ b/src/Common/DiscoverChangelogEntryListener.php
@@ -32,10 +32,10 @@ class DiscoverChangelogEntryListener
         $version       = $event->version();
         $contents      = file($filename) ?: [];
         $entry         = new ChangelogEntry();
-        $boundaryRegex = '/^(?:## (?:\d+\.\d+\.\d+|\[\d+\.\d+\.\d+\])|\[.*?\]:\s*\S+)/';
+        $boundaryRegex = '/^(?:## (?:\d+\.\d+\.\d+|\[\d+\.\d+\.\d+\]|unreleased|\[unreleased\])|\[.*?\]:\s*\S+)/i';
         $regex         = $version
             ? sprintf(
-                '/^## (?:%1$s|\[%1$s\])/',
+                '/^## (?:%1$s|\[%1$s\])/i',
                 preg_quote($version)
             )
             : $boundaryRegex;

--- a/src/Common/ValidateVersionListener.php
+++ b/src/Common/ValidateVersionListener.php
@@ -19,7 +19,7 @@ class ValidateVersionListener
     public function __invoke(VersionAwareEventInterface $event) : void
     {
         $version = $event->version() ?: '';
-        $pattern = sprintf('/^\d+\.\d+\.\d+(%s)?$/i', self::PRE_RELEASE_REGEX);
+        $pattern = sprintf('/^(\d+\.\d+\.\d+(%s)?|unreleased)$/i', self::PRE_RELEASE_REGEX);
         if (! preg_match($pattern, $version)) {
             $event->versionIsInvalid($version);
             return;

--- a/src/ListenerProvider.php
+++ b/src/ListenerProvider.php
@@ -77,6 +77,13 @@ class ListenerProvider implements ListenerProviderInterface
             Entry\PrependPatchLinkListener::class,
             Entry\AddChangelogEntryListener::class,
         ],
+        Unreleased\PromoteEvent::class             => [
+            Config\ConfigListener::class,
+            Unreleased\ValidateDateToUseListener::class,
+            Common\IsChangelogReadableListener::class,
+            Common\DiscoverChangelogEntryListener::class,
+            Unreleased\PromoteUnreleasedToNewVersionListener::class,
+        ],
         Version\EditChangelogVersionEvent::class   => [
             Config\ConfigListener::class,
             Common\IsChangelogReadableListener::class,

--- a/src/Unreleased/PromoteCommand.php
+++ b/src/Unreleased/PromoteCommand.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Unreleased;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function date;
+
+class PromoteCommand extends Command
+{
+    private const DESCRIPTION = 'Give a name to an unreleased version.';
+
+    private const HELP = <<<'EOH'
+Renames the current Unreleased version to the <version> provided, and sets the
+release date to today (unless the --date|-d option is provided).
+
+EOH;
+
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher, string $name = 'unreleased:promote')
+    {
+        $this->dispatcher = $dispatcher;
+        parent::__construct($name);
+    }
+
+    protected function configure() : void
+    {
+        $this->setDescription(self::DESCRIPTION);
+        $this->setHelp(self::HELP);
+
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'The version to promote the unreleased version to.'
+        );
+
+        $this->addOption(
+            'date',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Specific release date to use',
+            date('Y-m-d')
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        return $this->dispatcher
+                ->dispatch(new PromoteEvent(
+                    $input,
+                    $output,
+                    $this->dispatcher,
+                    $input->getArgument('version'),
+                    $input->getOption('date')
+                ))
+                ->failed()
+                    ? 1
+                    : 0;
+    }
+}

--- a/src/Unreleased/PromoteEvent.php
+++ b/src/Unreleased/PromoteEvent.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Common\AbstractEvent;
+use Phly\KeepAChangelog\Common\ChangelogEntryAwareEventInterface;
+use Phly\KeepAChangelog\Common\ChangelogEntryDiscoveryTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function sprintf;
+
+class PromoteEvent extends AbstractEvent implements ChangelogEntryAwareEventInterface
+{
+    use ChangelogEntryDiscoveryTrait;
+
+    /** @var string */
+    private $newVersion;
+
+    /** @var string */
+    private $releaseDate;
+
+    public function __construct(
+        InputInterface $input,
+        OutputInterface $output,
+        EventDispatcherInterface $dispatcher,
+        string $version,
+        string $releaseDate
+    ) {
+        $this->input       = $input;
+        $this->output      = $output;
+        $this->dispatcher  = $dispatcher;
+        $this->newVersion  = $version;
+        $this->releaseDate = $releaseDate;
+    }
+
+    public function isPropagationStopped() : bool
+    {
+        return $this->failed;
+    }
+
+    public function newVersion() : string
+    {
+        return $this->newVersion;
+    }
+
+    public function releaseDate() : string
+    {
+        return $this->releaseDate;
+    }
+
+    public function version() : string
+    {
+        return 'unreleased';
+    }
+
+    public function versionIsInvalid(string $version) : void
+    {
+        // intentional no-op; never should get called
+    }
+
+    public function didNotPromote() : void
+    {
+        $this->failed = true;
+        $this->output()->writeln('<error>Invalid date provided for release; must be in Y-m-d format</error>');
+    }
+
+    public function changelogReady() : void
+    {
+        $this->output->writeln(sprintf(
+            '<info>Renamed Unreleased entry to "%s" with release date of "%s"</info>',
+            $this->newVersion,
+            $this->releaseDate
+        ));
+    }
+}

--- a/src/Unreleased/PromoteUnreleasedToNewVersionListener.php
+++ b/src/Unreleased/PromoteUnreleasedToNewVersionListener.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Common\ChangelogEditSpawnerTrait;
+
+use function explode;
+use function implode;
+use function sprintf;
+
+class PromoteUnreleasedToNewVersionListener
+{
+    use ChangelogEditSpawnerTrait;
+
+    public function __invoke(PromoteEvent $event) : void
+    {
+        $entry    = $event->changelogEntry();
+        $lines    = explode("\n", $entry->contents);
+        $lines[0] = sprintf('## %s - %s', $event->newVersion(), $event->releaseDate());
+
+        $this->getChangelogEditor()->update(
+            $event->config()->changelogFile(),
+            implode("\n", $lines),
+            $entry
+        );
+
+        $event->changelogReady();
+    }
+}

--- a/src/Unreleased/ValidateDateToUseListener.php
+++ b/src/Unreleased/ValidateDateToUseListener.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Unreleased;
+
+use function preg_match;
+
+class ValidateDateToUseListener
+{
+    public function __invoke(PromoteEvent $event) : void
+    {
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $event->releaseDate())) {
+            return;
+        }
+
+        $event->didNotPromote();
+    }
+}

--- a/test/Bump/BumpChangelogVersionEventTest.php
+++ b/test/Bump/BumpChangelogVersionEventTest.php
@@ -87,4 +87,17 @@ class BumpChangelogVersionEventTest extends TestCase
 
         $this->assertNull($event->bumpedChangelog('1.2.3'));
     }
+
+    public function testWhenBumpVersionEqualsUnreleasedConstantVersionIsSetToUnreleasedConstant() : void
+    {
+        $event = new BumpChangelogVersionEvent(
+            $this->input,
+            $this->output->reveal(),
+            $this->dispatcher,
+            BumpChangelogVersionEvent::UNRELEASED
+        );
+
+        $this->assertSame(BumpChangelogVersionEvent::UNRELEASED, $event->version());
+        $this->assertNull($event->bumpMethod());
+    }
 }

--- a/test/Bump/BumpCommandTest.php
+++ b/test/Bump/BumpCommandTest.php
@@ -38,10 +38,11 @@ class BumpCommandTest extends TestCase
 
     public function expectedTypes() : iterable
     {
-        yield 'BUMP_MAJOR'  => [BumpCommand::BUMP_MAJOR, 'bumpMajorVersion'];
-        yield 'BUMP_MINOR'  => [BumpCommand::BUMP_MINOR, 'bumpMinorVersion'];
-        yield 'BUMP_PATCH'  => [BumpCommand::BUMP_PATCH, 'bumpPatchVersion'];
-        yield 'BUMP_BUGFIX' => [BumpCommand::BUMP_BUGFIX, 'bumpPatchVersion'];
+        yield 'BUMP_MAJOR'      => [BumpCommand::BUMP_MAJOR, 'bumpMajorVersion'];
+        yield 'BUMP_MINOR'      => [BumpCommand::BUMP_MINOR, 'bumpMinorVersion'];
+        yield 'BUMP_PATCH'      => [BumpCommand::BUMP_PATCH, 'bumpPatchVersion'];
+        yield 'BUMP_BUGFIX'     => [BumpCommand::BUMP_BUGFIX, 'bumpPatchVersion'];
+        yield 'BUMP_UNRELEASED' => [BumpCommand::BUMP_UNRELEASED, BumpChangelogVersionEvent::UNRELEASED];
     }
 
     /**
@@ -69,6 +70,13 @@ class BumpCommandTest extends TestCase
                 TestCase::assertSame($input->reveal(), $event->input());
                 TestCase::assertSame($output->reveal(), $event->output());
                 TestCase::assertSame($dispatcher->reveal(), $event->dispatcher());
+
+                if ($methodName === BumpChangelogVersionEvent::UNRELEASED) {
+                    TestCase::assertNull($event->bumpMethod());
+                    TestCase::assertSame(BumpChangelogVersionEvent::UNRELEASED, $event->version());
+                    return $event;
+                }
+
                 TestCase::assertSame($methodName, $event->bumpMethod());
                 TestCase::assertNull($event->version());
                 return $event;
@@ -98,6 +106,13 @@ class BumpCommandTest extends TestCase
                 TestCase::assertSame($input->reveal(), $event->input());
                 TestCase::assertSame($output->reveal(), $event->output());
                 TestCase::assertSame($dispatcher->reveal(), $event->dispatcher());
+
+                if ($methodName === BumpChangelogVersionEvent::UNRELEASED) {
+                    TestCase::assertNull($event->bumpMethod());
+                    TestCase::assertSame(BumpChangelogVersionEvent::UNRELEASED, $event->version());
+                    return $event;
+                }
+
                 TestCase::assertSame($methodName, $event->bumpMethod());
                 TestCase::assertNull($event->version());
                 return $event;

--- a/test/Common/ChangelogParserTest.php
+++ b/test/Common/ChangelogParserTest.php
@@ -290,7 +290,7 @@ EOC;
         $this->assertSame(3, $links->length);
     }
 
-    public function testCorrectlyIdentifiesUnreleasedVersion(): void
+    public function testCorrectlyIdentifiesUnreleasedVersion() : void
     {
         $changelog = __DIR__ . '/../_files/CHANGELOG-WITH-UNRELEASED-SECTION.md';
 
@@ -305,7 +305,7 @@ EOC;
         $this->assertSame($expected, $actual);
     }
 
-    public function unreleasedVariants(): iterable
+    public function unreleasedVariants() : iterable
     {
         yield 'unreleased' => ['unreleased'];
         yield 'UNRELEASED' => ['UNRELEASED'];
@@ -315,10 +315,10 @@ EOC;
     /**
      * @dataProvider unreleasedVariants
      */
-    public function testCorrectlyReturnsUnreleasedVersion(string $versionName): void
+    public function testCorrectlyReturnsUnreleasedVersion(string $versionName) : void
     {
         $changelogContents = file_get_contents(__DIR__ . '/../_files/CHANGELOG-WITH-UNRELEASED-SECTION.md');
-        $expected  = <<<'EOF'
+        $expected          = <<<'EOF'
 ### Added
 
 - Nothing.
@@ -340,7 +340,7 @@ EOC;
 - Nothing.
 
 EOF;
-        $changelog = $this->parser->findChangelogForVersion($changelogContents, $versionName);
+        $changelog         = $this->parser->findChangelogForVersion($changelogContents, $versionName);
 
         $this->assertEquals($expected, $changelog);
     }

--- a/test/Common/ChangelogParserTest.php
+++ b/test/Common/ChangelogParserTest.php
@@ -289,4 +289,59 @@ EOC;
         $this->assertSame(70, $links->index);
         $this->assertSame(3, $links->length);
     }
+
+    public function testCorrectlyIdentifiesUnreleasedVersion(): void
+    {
+        $changelog = __DIR__ . '/../_files/CHANGELOG-WITH-UNRELEASED-SECTION.md';
+
+        $expected = [
+            'Unreleased' => '',
+            '1.1.0'      => '2018-03-23',
+            '0.1.0'      => '2018-03-23',
+        ];
+
+        $actual = iterator_to_array($this->parser->findAllVersions($changelog));
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function unreleasedVariants(): iterable
+    {
+        yield 'unreleased' => ['unreleased'];
+        yield 'UNRELEASED' => ['UNRELEASED'];
+        yield 'Unreleased' => ['Unreleased'];
+    }
+
+    /**
+     * @dataProvider unreleasedVariants
+     */
+    public function testCorrectlyReturnsUnreleasedVersion(string $versionName): void
+    {
+        $changelogContents = file_get_contents(__DIR__ . '/../_files/CHANGELOG-WITH-UNRELEASED-SECTION.md');
+        $expected  = <<<'EOF'
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+EOF;
+        $changelog = $this->parser->findChangelogForVersion($changelogContents, $versionName);
+
+        $this->assertEquals($expected, $changelog);
+    }
 }

--- a/test/Common/ValidateVersionListenerTest.php
+++ b/test/Common/ValidateVersionListenerTest.php
@@ -75,6 +75,8 @@ class ValidateVersionListenerTest extends TestCase
         yield 'patch-shorter-uc'        => ['2.0.0P5', $isFailure = false];
         yield 'patch-long-hyphen'       => ['2.0.0-patch4', $isFailure = false];
         yield 'patch-long-hyphen-dot'   => ['2.0.0-patch.4', $isFailure = false];
+
+        yield 'unreleased'              => ['unreleased', $isFailure = false];
     }
 
     /**

--- a/test/Unreleased/PromoteCommandTest.php
+++ b/test/Unreleased/PromoteCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Unreleased\PromoteCommand;
+use Phly\KeepAChangelog\Unreleased\PromoteEvent;
+use PhlyTest\KeepAChangelog\ExecuteCommandTrait;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function date;
+
+class PromoteCommandTest extends TestCase
+{
+    use ExecuteCommandTrait;
+
+    /** @var PromoteCommand */
+    private $command;
+
+    /** @var EventDispatcherInterface|ObjectProphecy */
+    private $dispatcher;
+
+    public function setUp() : void
+    {
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->input      = $this->prophesize(InputInterface::class);
+        $this->output     = $this->prophesize(OutputInterface::class);
+        $this->command    = new PromoteCommand($this->dispatcher->reveal());
+    }
+
+    public function providedInput() : iterable
+    {
+        yield 'failed-version-only'         => [$failed = true, $version = '2.5.0', $date = null];
+        yield 'success-version-only'        => [$failed = false, $version = '2.5.0', $date = null];
+        yield 'failed-version-and-date'     => [$failed = true, $version = '2.5.0', $date = '2020-07-16'];
+        yield 'success-version-and-datenly' => [$failed = false, $version = '2.5.0', $date = '2020-07-16'];
+    }
+
+    /**
+     * @dataProvider providedInput
+     */
+    public function testReturnsExpectedExitCodeBasedOnEventDispatchStatus(
+        bool $failureStatus,
+        string $version,
+        ?string $date
+    ) : void {
+        $input      = $this->input;
+        $output     = $this->output;
+        $dispatcher = $this->dispatcher;
+        $date       = $date ?: date('Y-m-d');
+
+        $input->getArgument('version')->willReturn($version);
+        $input->getOption('date')->willReturn($date);
+
+        /** @var PromoteEvent|ObjectProphecy $event */
+        $event = $this->prophesize(PromoteEvent::class);
+        $event->failed()->willReturn($failureStatus);
+
+        $this->dispatcher
+            ->dispatch(Argument::that(
+                function ($event) use ($input, $output, $dispatcher, $version, $date) {
+                    /** @var PromoteEvent $event */
+                    TestCase::assertInstanceOf(PromoteEvent::class, $event);
+                    TestCase::assertSame($input->reveal(), $event->input());
+                    TestCase::assertSame($output->reveal(), $event->output());
+                    TestCase::assertSame($dispatcher->reveal(), $event->dispatcher());
+                    TestCase::assertSame($version, $event->newVersion());
+                    TestCase::assertSame($date, $event->releaseDate());
+
+                    return $event;
+                }
+            ))
+            ->will(function () use ($event) {
+                return $event->reveal();
+            });
+
+        $expectedStatus = $failureStatus ? 1 : 0;
+        $this->assertSame($expectedStatus, $this->executeCommand($this->command));
+    }
+}

--- a/test/Unreleased/PromoteEventTest.php
+++ b/test/Unreleased/PromoteEventTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Unreleased\PromoteEvent;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PromoteEventTest extends TestCase
+{
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    /** @var InputInterface */
+    private $input;
+
+    /** @var OutputInterface|ObjectProphecy */
+    private $output;
+
+    public function setUp() : void
+    {
+        $this->input      = $this->prophesize(InputInterface::class)->reveal();
+        $this->output     = $this->prophesize(OutputInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class)->reveal();
+    }
+
+    public function testConstructorSetsVersionNewVersionAndReleaseDate() : void
+    {
+        $event = new PromoteEvent(
+            $this->input,
+            $this->output->reveal(),
+            $this->dispatcher,
+            '2.5.0',
+            '2020-07-16'
+        );
+
+        $this->assertSame('unreleased', $event->version());
+        $this->assertSame('2.5.0', $event->newVersion());
+        $this->assertSame('2020-07-16', $event->releaseDate());
+    }
+
+    public function testCallingDidNotPromoteStopsPropagationAndEmitsOutput() : void
+    {
+        $event = new PromoteEvent(
+            $this->input,
+            $this->output->reveal(),
+            $this->dispatcher,
+            '2.5.0',
+            '2020-07-16'
+        );
+
+        $this->output->writeln(Argument::containingString('Invalid date'))->shouldBeCalled();
+
+        $event->didNotPromote();
+        $this->assertTrue($event->isPropagationStopped());
+    }
+
+    public function testCallingChangelogReadyEmitsOutputButDoesNotStopPropagation() : void
+    {
+        $event = new PromoteEvent(
+            $this->input,
+            $this->output->reveal(),
+            $this->dispatcher,
+            '2.5.0',
+            '2020-07-16'
+        );
+
+        $this->output
+            ->writeln(Argument::containingString(
+                'Renamed Unreleased entry to "2.5.0" with release date of "2020-07-16"'
+            ))
+            ->shouldBeCalled();
+
+        $event->changelogReady();
+        $this->assertFalse($event->isPropagationStopped());
+    }
+}

--- a/test/Unreleased/PromoteUnreleasedToNewVersionListenerTest.php
+++ b/test/Unreleased/PromoteUnreleasedToNewVersionListenerTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Common\ChangelogEditor;
+use Phly\KeepAChangelog\Common\ChangelogEntry;
+use Phly\KeepAChangelog\Config;
+use Phly\KeepAChangelog\Unreleased\PromoteEvent;
+use Phly\KeepAChangelog\Unreleased\PromoteUnreleasedToNewVersionListener;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+class PromoteUnreleasedToNewVersionListenerTest extends TestCase
+{
+    public function testWritesChangelogEntry() : void
+    {
+        $config = $this->prophesize(Config::class);
+        $config->changelogFile()->willReturn('changelog.txt');
+
+        $entry           = new ChangelogEntry();
+        $entry->contents = <<<'END'
+## Unreleased
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+END;
+        $entry->index    = 4;
+        $entry->length   = 22;
+
+        $event = $this->prophesize(PromoteEvent::class);
+        $event->changelogEntry()->willReturn($entry)->shouldBeCalled();
+        $event->newVersion()->willReturn('2.5.0')->shouldBeCalled();
+        $event->releaseDate()->willReturn('2020-07-16')->shouldBeCalled();
+        $event->config()->will([$config, 'reveal'])->shouldBeCalled();
+        $event->changelogReady()->shouldBeCalled();
+
+        $editor = $this->prophesize(ChangelogEditor::class);
+        $editor
+            ->update(
+                'changelog.txt',
+                Argument::containingString('## 2.5.0 - 2020-07-16'),
+                $entry
+            )
+            ->shouldBeCalled();
+
+        $listener                  = new PromoteUnreleasedToNewVersionListener();
+        $listener->changelogEditor = $editor->reveal();
+
+        $this->assertNull($listener($event->reveal()));
+    }
+}

--- a/test/Unreleased/ValidateDateToUseListenerTest.php
+++ b/test/Unreleased/ValidateDateToUseListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2020 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Unreleased;
+
+use Phly\KeepAChangelog\Unreleased\PromoteEvent;
+use Phly\KeepAChangelog\Unreleased\ValidateDateToUseListener;
+use PHPUnit\Framework\TestCase;
+
+class ValidateDateToUseListenerTest extends TestCase
+{
+    public function testDoesNothingIfReleaseDateIsValid() : void
+    {
+        $event = $this->prophesize(PromoteEvent::class);
+        $event->releaseDate()->willReturn('2020-07-16')->shouldBeCalled();
+
+        $listener = new ValidateDateToUseListener();
+
+        $this->assertNull($listener($event->reveal()));
+        $event->didNotPromote()->shouldNotHaveBeenCalled();
+    }
+
+    public function testNotifiesEventOfInabilityToPromote() : void
+    {
+        $event = $this->prophesize(PromoteEvent::class);
+        $event->releaseDate()->willReturn('TBD')->shouldBeCalled();
+        $event->didNotPromote()->shouldBeCalled();
+
+        $listener = new ValidateDateToUseListener();
+
+        $this->assertNull($listener($event->reveal()));
+    }
+}

--- a/test/_files/CHANGELOG-WITH-LINKED-UNRELEASED-SECTION.md
+++ b/test/_files/CHANGELOG-WITH-LINKED-UNRELEASED-SECTION.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## [Unreleased]
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Added a new feature.
+
+### Changed
+
+- Made some changes.
+
+### Deprecated
+
+- Nothing was deprecated.
+
+### Removed
+
+- Nothing was removed.
+
+### Fixed
+
+- Fixed some bugs.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+[Unreleased]: https://example.com/compare/1.1.0...latest

--- a/test/_files/CHANGELOG-WITH-UNRELEASED-SECTION.md
+++ b/test/_files/CHANGELOG-WITH-UNRELEASED-SECTION.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## Unreleased
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Added a new feature.
+
+### Changed
+
+- Made some changes.
+
+### Deprecated
+
+- Nothing was deprecated.
+
+### Removed
+
+- Nothing was removed.
+
+### Fixed
+
+- Fixed some bugs.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.


### PR DESCRIPTION
Per the 1.0 version of the Keep-A-Changelog specification, changelogs may optionally have an "Unreleased" version at the top of the file. The version should not have a date, but otherwise has the same format as other changelogs. Doing so allows developers to choose the release version only when ready to release (e.g., when unsure if a new version will be a new minor or a new major version).

This patch provides support in the changelog parser for identifying and retrieving "Unreleased" versions, ensuring that when one is present, all commands (e.g., `version:show`, `version:edit`, `version:list`, etc.) continue to work.

Additionally, it provides the following new commands:

- `unreleased:create` will create a version named 'Unreleased' at the top of the changelog file.
- `unreleased:promote <version> [--date|-d]` will rename the `Unreleased` section to the specified version, setting the release date at the same time. If no release date is provided, it uses the current date.

Closes #68 