### PR TITLE
Add accessor methods to ChangelogEntry class

### DIFF
--- a/src/Changelog/EditChangelogLinksListener.php
+++ b/src/Changelog/EditChangelogLinksListener.php
@@ -25,7 +25,7 @@ class EditChangelogLinksListener
     {
         $changelog = $event->config()->changelogFile();
         $links     = $event->links();
-        $contents  = $links instanceof ChangelogEntry ? $links->contents : '';
+        $contents  = $links instanceof ChangelogEntry ? $links->contents() : '';
         $tempFile  = $this->createTempFileWithContents($contents);
 
         $status = $this->getEditor()->spawnEditor(

--- a/src/Common/ChangelogEntry.php
+++ b/src/Common/ChangelogEntry.php
@@ -70,6 +70,21 @@ class ChangelogEntry
         }
     }
 
+    public function contents(): string
+    {
+        return $this->contents;
+    }
+
+    public function index(): int
+    {
+        return $this->index;
+    }
+
+    public function length(): int
+    {
+        return $this->length;
+    }
+
     private function setContents(string $value): void
     {
         $this->contents = $value;
@@ -77,7 +92,7 @@ class ChangelogEntry
 
     private function setIndex(?int $value): void
     {
-        $this->index = $value;
+        $this->index = $value ?: 0;
     }
 
     private function setLength(int $value): void

--- a/test/Common/ChangelogEntryTest.php
+++ b/test/Common/ChangelogEntryTest.php
@@ -100,4 +100,18 @@ class ChangelogEntryTest extends TestCase
         $this->expectException(TypeError::class);
         $this->entry->contents = $value;
     }
+
+    public function testAccessorsProxyToProperties(): void
+    {
+        $contents              = 'This is the contents';
+        $length                = 1;
+        $index                 = 0;
+        $this->entry->contents = $contents;
+        $this->entry->index    = $index;
+        $this->entry->length   = $length;
+
+        $this->assertSame($contents, $this->entry->contents());
+        $this->assertSame($index, $this->entry->index());
+        $this->assertSame($length, $this->entry->length());
+    }
 }


### PR DESCRIPTION
Using `__get()` is problematic from a standpoint of using the class with strict types, as `__get()` returns `mixed`. Adding actual accessors fixes the issue.