### PR TITLE
fix: add missing use statement to fix class not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.8.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#79](https://github.com/phly/keep-a-changelog/pull/79) fixes a case where the `bump` command (and its subcommands) would result in a fatal error if unable to detect any changelog entries.
+
 ## 2.8.0 - 2020-08-03
 
 ### Added

--- a/src/Bump/ChangelogBump.php
+++ b/src/Bump/ChangelogBump.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Phly\KeepAChangelog\Bump;
 
+use Phly\KeepAChangelog\Exception;
+
 use function explode;
 use function file_get_contents;
 use function file_put_contents;

--- a/test/Bump/ChangelogBumpTest.php
+++ b/test/Bump/ChangelogBumpTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace PhlyTest\KeepAChangelog\Bump;
 
 use Phly\KeepAChangelog\Bump\ChangelogBump;
+use Phly\KeepAChangelog\Exception\ChangelogEntriesNotFoundException;
 use PHPUnit\Framework\TestCase;
 
 use function file_get_contents;
@@ -206,5 +207,16 @@ EOC;
 
         $this->bumper->updateChangelog('3.2.1');
         $this->assertEquals($expected, file_get_contents($this->tempFile));
+    }
+
+    public function testFindLatestVersionThrowsExceptionIfNoChangelogEntriesFound(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'KAC');
+        file_put_contents($this->tempFile, 'There are no changelog entries here');
+        $bumper = new ChangelogBump($tempFile);
+
+        $this->expectException(ChangelogEntriesNotFoundException::class);
+
+        $bumper->findLatestVersion();
     }
 }


### PR DESCRIPTION
While attempting to use `keep-a-changelog bump:minor` for the first time, I encountered the following error:

```
PHP Fatal error:  Uncaught Error: Class 'Phly\KeepAChangelog\Bump\Exception\ChangelogEntriesNotFoundException' not found in /path/to/ramsey/devtools/vendor/phly/keep-a-changelog/src/Bump/ChangelogBump.php:70
```

I investigated and found that the exception class was not resolving properly because of a missing `use` statement. This PR adds the missing `use` statement and includes a test to ensure the exception is thrown.

Now, the `bump:minor` command properly responds with this, if it can't find any changelog entries:

```
In ChangelogEntriesNotFoundException.php line 21:
                                                                                                            
  Unable to find any changelog entries in file /path/to/ramsey/devtools/CHANGELOG.md; is it  
   formatted correctly?                                                                                     
                                                                                                            

bump:minor [-m|--create-milestone] [--create-milestone-with-name CREATE-MILESTONE-WITH-NAME]
```