### PR TITLE
feat: support a verbose heading for the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.9.0 - TBD
+
+### Added
+
+- [#80](https://github.com/phly/keep-a-changelog/pull/80) adds support for more verbose changelog headings. The heading no longer must be exactly `# Changelog`. Rather, it can be `# My Project's Changelog` or `# The changelog for all the things`. The word "changelog" must still be somewhere in the heading.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.8.1 - 2020-09-01
 
 ### Added

--- a/src/Bump/ChangelogBump.php
+++ b/src/Bump/ChangelogBump.php
@@ -107,7 +107,7 @@ EOT;
         $changelog = sprintf(self::TEMPLATE, $version);
         $contents  = file_get_contents($this->changelogFile);
         $contents  = preg_replace(
-            "/^(\# Changelog\n\n.*?)(\n\n\#\# )/s",
+            "/^(\# [^\n]*Changelog[^\n]*\n\n.*?)(\n\n\#\# )/si",
             '$1' . $changelog . '## ',
             $contents
         );

--- a/test/Bump/ChangelogBumpTest.php
+++ b/test/Bump/ChangelogBumpTest.php
@@ -219,4 +219,124 @@ EOC;
 
         $bumper->findLatestVersion();
     }
+
+    public function testUpdateChangelogPrependsNewEntryWhenChangelogHasExpandedHeading(): void
+    {
+        $expected = <<<'EOC'
+# my/project's ChAnGeLoG of Notable Changes
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.0.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.2.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.1.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 0.1.0 - 2020-08-31
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+EOC;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'KAC');
+        file_put_contents(
+            $tempFile,
+            file_get_contents(__DIR__ . '/../_files/CHANGELOG-WITH-EXPANDED-HEADING.md')
+        );
+        $bumper = new ChangelogBump($tempFile);
+
+        $currentVersion = $bumper->findLatestVersion();
+        $currentVersion = $bumper->bumpPatchVersion($currentVersion);
+        $bumper->updateChangelog($currentVersion);
+
+        $currentVersion = $bumper->bumpMinorVersion($currentVersion);
+        $bumper->updateChangelog($currentVersion);
+
+        $currentVersion = $bumper->bumpMajorVersion($currentVersion);
+        $bumper->updateChangelog($currentVersion);
+
+        $this->assertEquals($expected, file_get_contents($tempFile));
+    }
 }

--- a/test/_files/CHANGELOG-WITH-EXPANDED-HEADING.md
+++ b/test/_files/CHANGELOG-WITH-EXPANDED-HEADING.md
@@ -1,0 +1,28 @@
+# my/project's ChAnGeLoG of Notable Changes
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 - 2020-08-31
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.


### PR DESCRIPTION
This PR addresses the reason I stumbled upon #79.

I tend to use headings similar to the following for my `CHANGELOG.md` files:

``` markdown
# ramsey/devtools Changelog
```

When I ran `keep-a-changelog bump` against an existing (created before installing phly/keep-a-changelog) `CHANGELOG.md`, I got the following error (after applying the patch from PR #79):

```
Unable to find any changelog entries in file /path/to/ramsey/devtools/CHANGELOG.md; is it formatted correctly? 
```

This error occurs because the regular expression in `ChangelogBump::updateChangelog()` expects a strict heading of:

``` markdown
# Changelog
```

Since Keep A Changelog is not an exact specification (it's a convention), I would like to relax the strictness here. I still think the word "changelog" should be in the heading, so this new regular expression enforces this, but it allows for content to come before and after the word "changelog," and it allows "changelog" to be case-insensitive.
