### PR TITLE
fix: resolve issues with scoped classes in PHAR

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,4 +1,5 @@
 {
   "output": "build/keep-a-changelog.phar",
-  "compactors": ["KevinGH\\Box\\Compactor\\PhpScoper"]
+  "compactors": ["KevinGH\\Box\\Compactor\\PhpScoper"],
+  "php-scoper": "scoper.inc.php"
 }

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'whitelist' => [
+        // Whitelist providers
+        'Phly\KeepAChangelog\Provider\GitHub',
+        'Phly\KeepAChangelog\Provider\GitLab',
+        'Phly\KeepAChangelog\Provider\MilestoneAwareProviderInterface',
+        'Phly\KeepAChangelog\Provider\ProviderInterface',
+    ],
+    // Necessary for allowing polyfill classes
+    'whitelist-global-classes' => false,
+];

--- a/src/ConfigCommand/CreateLocalConfigListener.php
+++ b/src/ConfigCommand/CreateLocalConfigListener.php
@@ -11,22 +11,11 @@ declare(strict_types=1);
 namespace Phly\KeepAChangelog\ConfigCommand;
 
 use function getcwd;
+use function implode;
 use function sprintf;
 
 class CreateLocalConfigListener extends AbstractCreateConfigListener
 {
-    private const TEMPLATE = <<<'EOT'
-[defaults]
-changelog_file = %s
-provider = github
-remote = origin
-
-[providers]
-github[class] = Phly\KeepAChangelog\Provider\GitHub
-gitlab[class] = Phly\KeepAChangelog\Provider\GitLab
-
-EOT;
-
     public function configCreateRequested(CreateConfigEvent $event): bool
     {
         return $event->createLocal();
@@ -39,7 +28,18 @@ EOT;
 
     public function getConfigTemplate(): string
     {
-        return self::TEMPLATE;
+        // Done this way due to issues with PHAR creation
+        return implode("\n", [
+            '[defaults]',
+            'changelog_file = %s',
+            'provider = github',
+            'remote = origin',
+            '',
+            '[providers]',
+            'github[class] = Phly\KeepAChangelog\Provider\GitHub',
+            'gitlab[class] = Phly\KeepAChangelog\Provider\GitLab',
+            '',
+        ]);
     }
 
     /**


### PR DESCRIPTION
This patch makes several changes to PHAR creation to resolve the following issues:

- Generated local configuration files were receiving the autogenerated namespace as a prefix to the configuration.
  This is likely a bug in Box and/or PHP-Scoper, but it's possible to work around it (I chose `implode()` with a list of lines, as any nowdoc or heredoc triggered the injection for me).

- Configuration files reference provider classes.
  This led to problems when scoping as those classes then could not be found.
  I have added php-scoper whitelist entries for the specified classes to ensure that configuration can be used and not lead to errors.

- Once php-scoper configuration was introduced, I started seeing warnings thrown around polyfill classes we use.
  I have updated the php-scoper configuration to whitelist global classes.

In my local testing, all operations that previously did not work under the PHAR now work.

Fixes #81
Fixes #82