### PR TITLE
fix: emit error message in config:create if no option provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#89](https://github.com/phly/keep-a-changelog/pull/89) fixes the `config:create` command to emit an error message and return a non-zero status when neither the `--local|-l` nor the `--global|-g` options have been provided.
+
 - [#88](https://github.com/phly/keep-a-changelog/pull/88) fixes an issue where using the phly/keep-a-changelog PHAR with configuration would lead to errors about the inability to locate provider classes. These are now resolved correctly by the PHAR.
 
 - [#88](https://github.com/phly/keep-a-changelog/pull/88) fixes an issue whereby calling `config:create -l` with a phly/keep-a-changelog PHAR file would result in unusable local configuration due to a string injected in the config template during PHAR creation.

--- a/src/ConfigCommand/CreateCommand.php
+++ b/src/ConfigCommand/CreateCommand.php
@@ -62,12 +62,20 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $localRequested  = $input->getOption('local') ?: false;
+        $globalRequested = $input->getOption('global') ?: false;
+
+        if (! $localRequested && ! $globalRequested) {
+            $output->writeln('<error>You MUST specify one or both of either --local|-l OR --global|-g</error>');
+            return 1;
+        }
+
         return $this->dispatcher
                 ->dispatch(new CreateConfigEvent(
                     $input,
                     $output,
-                    $input->getOption('local') ?: false,
-                    $input->getOption('global') ?: false,
+                    $localRequested,
+                    $globalRequested,
                     $input->getOption('changelog') ?: null
                 ))
                 ->failed()

--- a/test/ConfigCommand/CreateCommandTest.php
+++ b/test/ConfigCommand/CreateCommandTest.php
@@ -71,4 +71,23 @@ class CreateCommandTest extends TestCase
 
         $this->assertSame($expectedStatus, $this->executeCommand($command));
     }
+
+    public function testExecutionReturnsOneAndEmitsErrorMessageWhenNeitherLocalNorGlobalOptionProvided(): void
+    {
+        $input = $this->input;
+        $input->getOption('local')->willReturn(null);
+        $input->getOption('global')->willReturn(null);
+
+        $output = $this->output;
+        $output
+            ->writeln(Argument::containingString('--local|-l OR --global|-g'))
+            ->shouldBeCalled();
+
+        $dispatcher = $this->dispatcher;
+        $dispatcher->dispatch(Argument::any())->shouldNotBeCalled();
+
+        $command = new CreateCommand($this->dispatcher->reveal());
+
+        $this->assertSame(1, $this->executeCommand($command));
+    }
 }


### PR DESCRIPTION
This patch updates `Phly\KeepAChangelog\ConfigCommand\CreateCommand` to emit an error message and return a non-zero status when neither the local nor global config options are specified.

Fixes #83