### PR TITLE
Provide message indicating invalid credentials

### DIFF
--- a/src/Milestone/CloseMilestoneEvent.php
+++ b/src/Milestone/CloseMilestoneEvent.php
@@ -54,11 +54,30 @@ class CloseMilestoneEvent extends AbstractMilestoneProviderEvent
     public function errorClosingMilestone(Throwable $e): void
     {
         $this->failed = true;
-        $output       = $this->output();
+
+        if ((int) $e->getCode() === 401) {
+            $this->reportAuthenticationException($e);
+            return;
+        }
+
+        $this->reportStandardException($e);
+    }
+
+    private function reportStandardException(Throwable $e): void
+    {
+        $output = $this->output();
 
         $output->writeln('<error>Error closing milestone!</error>');
         $output->writeln('An error occurred when attempting to close the milestone:');
         $output->writeln('');
         $output->writeln('Error Message: ' . $e->getMessage());
+    }
+
+    private function reportAuthenticationException(Throwable $e): void
+    {
+        $output = $this->output();
+
+        $output->writeln('<error>Invalid credentials</error>');
+        $output->writeln('The credentials associated with your Git provider are invalid.');
     }
 }

--- a/src/Milestone/CreateMilestoneEvent.php
+++ b/src/Milestone/CreateMilestoneEvent.php
@@ -66,11 +66,30 @@ class CreateMilestoneEvent extends AbstractMilestoneProviderEvent
     public function errorCreatingMilestone(Throwable $e): void
     {
         $this->failed = true;
-        $output       = $this->output();
+
+        if ((int) $e->getCode() === 401) {
+            $this->reportAuthenticationException($e);
+            return;
+        }
+
+        $this->reportStandardException($e);
+    }
+
+    private function reportStandardException(Throwable $e): void
+    {
+        $output = $this->output();
 
         $output->writeln('<error>Error creating milestone!</error>');
         $output->writeln('An error occurred when attempting to create the milestone:');
         $output->writeln('');
         $output->writeln('Error Message: ' . $e->getMessage());
+    }
+
+    private function reportAuthenticationException(Throwable $e): void
+    {
+        $output = $this->output();
+
+        $output->writeln('<error>Invalid credentials</error>');
+        $output->writeln('The credentials associated with your Git provider are invalid.');
     }
 }

--- a/src/Milestone/ListMilestonesEvent.php
+++ b/src/Milestone/ListMilestonesEvent.php
@@ -64,11 +64,30 @@ class ListMilestonesEvent extends AbstractMilestoneProviderEvent
     public function errorListingMilestones(Throwable $e): void
     {
         $this->failed = true;
-        $output       = $this->output();
+
+        if ((int) $e->getCode() === 401) {
+            $this->reportAuthenticationException($e);
+            return;
+        }
+
+        $this->reportStandardException($e);
+    }
+
+    private function reportStandardException(Throwable $e): void
+    {
+        $output = $this->output();
 
         $output->writeln('<error>Error listing milestones!</error>');
         $output->writeln('An error occurred when attempting to retrieve milestones from your provider:');
         $output->writeln('');
         $output->writeln('Error Message: ' . $e->getMessage());
+    }
+
+    private function reportAuthenticationException(Throwable $e): void
+    {
+        $output = $this->output();
+
+        $output->writeln('<error>Invalid credentials</error>');
+        $output->writeln('The credentials associated with your Git provider are invalid.');
     }
 }

--- a/src/Version/ReleaseEvent.php
+++ b/src/Version/ReleaseEvent.php
@@ -138,17 +138,12 @@ class ReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterface
     public function errorCreatingRelease(Throwable $e): void
     {
         $this->failed = true;
-        $output       = $this->output();
+        if ((int) $e->getCode() === 401) {
+            $this->reportAuthenticationException($e);
+            return;
+        }
 
-        $output->writeln('<error>Error creating release!</error>');
-        $output->writeln('The following error was caught when attempting to create the release:');
-        $output->writeln(sprintf(
-            "[%s: %d] %s\n%s",
-            gettype($e),
-            $e->getCode(),
-            $e->getMessage(),
-            $e->getTraceAsString()
-        ));
+        $this->reportStandardException($e);
     }
 
     public function unexpectedProviderResult(): void
@@ -163,5 +158,28 @@ class ReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterface
             . ' You will need to manually create the release.',
             gettype($this->provider)
         ));
+    }
+
+    private function reportStandardException(Throwable $e): void
+    {
+        $output = $this->output();
+
+        $output->writeln('<error>Error creating release!</error>');
+        $output->writeln('The following error was caught when attempting to create the release:');
+        $output->writeln(sprintf(
+            "[%s: %d] %s\n%s",
+            gettype($e),
+            $e->getCode(),
+            $e->getMessage(),
+            $e->getTraceAsString()
+        ));
+    }
+
+    private function reportAuthenticationException(Throwable $e): void
+    {
+        $output = $this->output();
+
+        $output->writeln('<error>Invalid credentials</error>');
+        $output->writeln('The credentials associated with your Git provider are invalid.');
     }
 }

--- a/test/Milestone/CloseMilestoneEventTest.php
+++ b/test/Milestone/CloseMilestoneEventTest.php
@@ -101,4 +101,30 @@ class CloseMilestoneEventTest extends TestCase
 
         $this->assertNull($event->errorClosingMilestone($e));
     }
+
+    public function testMilestoneCloseErrorDueToAuthenticationProvidesUniqueMessage(): void
+    {
+        $e = new RuntimeException('this is the error message', 401);
+
+        $output = $this->output;
+        $output
+            ->writeln(Argument::containingString('Invalid credentials'))
+            ->will(function () use ($output) {
+                $output
+                    ->writeln(Argument::containingString(
+                        'The credentials associated with your Git provider are invalid'
+                    ))
+                    ->shouldBeCalled();
+            })
+            ->shouldBeCalled();
+
+        $event = new CloseMilestoneEvent(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            $this->dispatcher->reveal()
+        );
+
+        $this->assertNull($event->errorClosingMilestone($e));
+        $this->assertTrue($event->failed());
+    }
 }

--- a/test/Milestone/CreateMilestoneEventTest.php
+++ b/test/Milestone/CreateMilestoneEventTest.php
@@ -98,4 +98,24 @@ class CreateMilestoneEventTest extends TestCase
         $this->assertNull($this->event->errorCreatingMilestone($e));
         $this->assertTrue($this->event->failed());
     }
+
+    public function testMilestoneCreationErrorDueToAuthenticationProvidesUniqueMessage(): void
+    {
+        $e = new RuntimeException('this is the error message', 401);
+
+        $output = $this->output;
+        $output
+            ->writeln(Argument::containingString('Invalid credentials'))
+            ->will(function () use ($output) {
+                $output
+                    ->writeln(Argument::containingString(
+                        'The credentials associated with your Git provider are invalid'
+                    ))
+                    ->shouldBeCalled();
+            })
+            ->shouldBeCalled();
+
+        $this->assertNull($this->event->errorCreatingMilestone($e));
+        $this->assertTrue($this->event->failed());
+    }
 }

--- a/test/Milestone/ListMilestonesEventTest.php
+++ b/test/Milestone/ListMilestonesEventTest.php
@@ -125,4 +125,24 @@ class ListMilestonesEventTest extends TestCase
 
         $this->assertNull($this->event->errorListingMilestones($e));
     }
+
+    public function testMilestoneRetrievalErrorDueToAuthenticationProvidesUniqueMessage(): void
+    {
+        $e = new RuntimeException('this is the error message', 401);
+
+        $output = $this->output;
+        $output
+            ->writeln(Argument::containingString('Invalid credentials'))
+            ->will(function () use ($output) {
+                $output
+                    ->writeln(Argument::containingString(
+                        'The credentials associated with your Git provider are invalid'
+                    ))
+                    ->shouldBeCalled();
+            })
+            ->shouldBeCalled();
+
+        $this->assertNull($this->event->errorListingMilestones($e));
+        $this->assertTrue($this->event->failed());
+    }
 }

--- a/test/Version/ReleaseEventTest.php
+++ b/test/Version/ReleaseEventTest.php
@@ -185,4 +185,24 @@ class ReleaseEventTest extends TestCase
         $this->assertTrue($this->event->isPropagationStopped());
         $this->assertTrue($this->event->failed());
     }
+
+    public function testReleaseCreationErrorDueToAuthenticationProvidesUniqueMessage(): void
+    {
+        $e = new RuntimeException('this is the error message', 401);
+
+        $output = $this->output;
+        $output
+            ->writeln(Argument::containingString('Invalid credentials'))
+            ->will(function () use ($output) {
+                $output
+                    ->writeln(Argument::containingString(
+                        'The credentials associated with your Git provider are invalid'
+                    ))
+                    ->shouldBeCalled();
+            })
+            ->shouldBeCalled();
+
+        $this->assertNull($this->event->errorCreatingRelease($e));
+        $this->assertTrue($this->event->failed());
+    }
 }


### PR DESCRIPTION
When invalid credentials are the reason for an event failing report that fact, instead of a generic exception message.

Fixes #85