### PR TITLE
Better messaging around various tagging failures

### DIFF
--- a/src/Version/CheckTreeForChangesListener.php
+++ b/src/Version/CheckTreeForChangesListener.php
@@ -41,9 +41,7 @@ class CheckTreeForChangesListener
         $exec($command, $output, $status);
 
         if ($status !== 0 || count($output) > 0) {
-            $event->taggingFailed();
-            $event->output()->write('<error>You have changes present in your tree that are not checked in.</error>');
-            $event->output()->write('Either check them in, or use the --force flag.');
+            $event->unversionedChangesPresent();
         }
     }
 }

--- a/src/Version/TagCommand.php
+++ b/src/Version/TagCommand.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function sprintf;
+
 class TagCommand extends Command
 {
     use CommonConfigOptionsTrait;
@@ -39,6 +41,11 @@ message format:
 By default, the tool assumes that the current working directory is the package
 name; if this is not the case, provide that optional argument when invoking the
 tool.
+
+NOTE: in some cases, you may need to run the following command to ensure
+gpg operations (for signing tags) will work correctly:
+
+    export GPG_TTY=$(tty)
 
 EOH;
 
@@ -76,6 +83,9 @@ EOH;
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $version = $input->getArgument('version');
+
+        $output->writeln(sprintf('<info>Preparing to tag version %s</info>', $version));
+
         return $this->dispatcher
                 ->dispatch(new TagReleaseEvent(
                     $input,

--- a/src/Version/TagReleaseEvent.php
+++ b/src/Version/TagReleaseEvent.php
@@ -68,10 +68,27 @@ class TagReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterf
         $this->output->write($this->changelog());
     }
 
-    public function taggingFailed(): void
+    public function tagOperationFailed(): void
     {
         $this->failed = true;
         $this->output->writeln('<error>Error creating tag!</error>');
-        $this->output->writeln('Check the output logs for details');
+        $this->output->writeln('The "git tag" operation failed; check the output logs for details');
+    }
+
+    public function unversionedChangesPresent(): void
+    {
+        $this->failed = true;
+        $this->output->writeln('<error>You have changes present in your tree that are not checked in.</error>');
+        $this->output->writeln('Either check them in, or use the --force flag.');
+    }
+
+    public function changelogMissingDate(): void
+    {
+        $this->failed = true;
+        $this->output->writeln(sprintf(
+            '<error>Version %s does not have a release date associated with it!</error>',
+            $this->version()
+        ));
+        $this->output->writeln('<error>You may need to run version:ready first</error>');
     }
 }

--- a/src/Version/TagReleaseListener.php
+++ b/src/Version/TagReleaseListener.php
@@ -29,7 +29,7 @@ class TagReleaseListener
                 $event->changelog()
             )
         ) {
-            $event->taggingFailed();
+            $event->tagOperationFailed();
             return;
         }
 

--- a/src/Version/VerifyVersionHasReleaseDateListener.php
+++ b/src/Version/VerifyVersionHasReleaseDateListener.php
@@ -14,7 +14,6 @@ use Phly\KeepAChangelog\Common\ChangelogParser;
 use Phly\KeepAChangelog\Exception\ChangelogMissingDateException;
 
 use function file_get_contents;
-use function sprintf;
 
 class VerifyVersionHasReleaseDateListener
 {
@@ -29,12 +28,7 @@ class VerifyVersionHasReleaseDateListener
                 true
             );
         } catch (ChangelogMissingDateException $e) {
-            $event->taggingFailed();
-            $event->output()->writeln(sprintf(
-                '<error>Version %s does not have a release date associated with it!</error>',
-                $event->version()
-            ));
-            $event->output()->writeln('<error>You may need to run version:ready first</error>');
+            $event->changelogMissingDate();
         }
     }
 }

--- a/test/Version/CheckTreeForChangesListenerTest.php
+++ b/test/Version/CheckTreeForChangesListenerTest.php
@@ -13,7 +13,6 @@ namespace PhlyTest\KeepAChangelog\Version;
 use Phly\KeepAChangelog\Version\CheckTreeForChangesListener;
 use Phly\KeepAChangelog\Version\TagReleaseEvent;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,7 +25,7 @@ class CheckTreeForChangesListenerTest extends TestCase
 
         $event = $this->prophesize(TagReleaseEvent::class);
         $event->input()->will([$input, 'reveal'])->shouldBeCalled();
-        $event->taggingFailed()->shouldNotBeCalled();
+        $event->unversionedChangesPresent()->shouldNotBeCalled();
         $event->output()->shouldNotBeCalled();
 
         $listener = new CheckTreeForChangesListener();
@@ -40,7 +39,7 @@ class CheckTreeForChangesListenerTest extends TestCase
 
         $event = $this->prophesize(TagReleaseEvent::class);
         $event->input()->will([$input, 'reveal'])->shouldBeCalled();
-        $event->taggingFailed()->shouldNotBeCalled();
+        $event->unversionedChangesPresent()->shouldNotBeCalled();
         $event->output()->shouldNotBeCalled();
 
         $listener       = new CheckTreeForChangesListener();
@@ -53,17 +52,13 @@ class CheckTreeForChangesListenerTest extends TestCase
 
     public function testListenerNotifesEventThatTaggingFailedIfForceFlagNotPresentAndTreeIsDirty(): void
     {
-        $input = $this->prophesize(InputInterface::class);
-        $input->getOption('force')->willReturn(null)->shouldBeCalled();
-
+        $input  = $this->prophesize(InputInterface::class);
         $output = $this->prophesize(OutputInterface::class);
-        $output->write(Argument::containingString('not checked in'))->shouldBeCalled();
-        $output->write(Argument::containingString('use the --force'))->shouldBeCalled();
+        $event  = $this->prophesize(TagReleaseEvent::class);
 
-        $event = $this->prophesize(TagReleaseEvent::class);
+        $input->getOption('force')->willReturn(null)->shouldBeCalled();
         $event->input()->will([$input, 'reveal'])->shouldBeCalled();
-        $event->taggingFailed()->shouldBeCalled();
-        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+        $event->unversionedChangesPresent()->shouldBeCalled();
 
         $listener       = new CheckTreeForChangesListener();
         $listener->exec = function ($command, &$output, &$return) {
@@ -76,17 +71,13 @@ class CheckTreeForChangesListenerTest extends TestCase
 
     public function testListenerNotifesEventThatTaggingFailedIfForceFlagNotPresentAndStatusCheckFails(): void
     {
-        $input = $this->prophesize(InputInterface::class);
-        $input->getOption('force')->willReturn(null)->shouldBeCalled();
-
+        $input  = $this->prophesize(InputInterface::class);
         $output = $this->prophesize(OutputInterface::class);
-        $output->write(Argument::containingString('not checked in'))->shouldBeCalled();
-        $output->write(Argument::containingString('use the --force'))->shouldBeCalled();
+        $event  = $this->prophesize(TagReleaseEvent::class);
 
-        $event = $this->prophesize(TagReleaseEvent::class);
+        $input->getOption('force')->willReturn(null)->shouldBeCalled();
         $event->input()->will([$input, 'reveal'])->shouldBeCalled();
-        $event->taggingFailed()->shouldBeCalled();
-        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+        $event->unversionedChangesPresent()->shouldBeCalled();
 
         $listener       = new CheckTreeForChangesListener();
         $listener->exec = function ($command, &$output, &$return) {

--- a/test/Version/TagReleaseEventTest.php
+++ b/test/Version/TagReleaseEventTest.php
@@ -125,19 +125,48 @@ class TagReleaseEventTest extends TestCase
         $this->assertFalse($event->failed());
     }
 
-    public function testMarkingTaggingFailedEmitsOutputAndStopsPropagationWithFailure()
+    public function testTagOperationFailedMarksEventFailed(): void
     {
         $event = $this->createEvent('1.2.3', 'v1.2.3');
 
-        $this->assertNull($event->taggingFailed());
+        $event->tagOperationFailed();
 
         $this->output
-            ->writeln(Argument::containingString('Error creating tag!'))
+            ->writeln(Argument::containingString('Error creating tag'))
             ->shouldHaveBeenCalled();
         $this->output
-            ->writeln(Argument::containingString('Check the output logs'))
+            ->writeln(Argument::containingString('"git tag" operation failed'))
             ->shouldHaveBeenCalled();
-        $this->assertTrue($event->isPropagationStopped());
+        $this->assertTrue($event->failed());
+    }
+
+    public function testUnversionedChangesPresentMarksEventFailed(): void
+    {
+        $event = $this->createEvent('1.2.3', 'v1.2.3');
+
+        $event->unversionedChangesPresent();
+
+        $this->output
+            ->writeln(Argument::containingString('changes present'))
+            ->shouldHaveBeenCalled();
+        $this->output
+            ->writeln(Argument::containingString('check them in'))
+            ->shouldHaveBeenCalled();
+        $this->assertTrue($event->failed());
+    }
+
+    public function testChangelogMissingDateMarksEventFailed(): void
+    {
+        $event = $this->createEvent('1.2.3', 'v1.2.3');
+
+        $event->changelogMissingDate();
+
+        $this->output
+            ->writeln(Argument::containingString('does not have a release date associated'))
+            ->shouldHaveBeenCalled();
+        $this->output
+            ->writeln(Argument::containingString('run version:ready'))
+            ->shouldHaveBeenCalled();
         $this->assertTrue($event->failed());
     }
 }

--- a/test/Version/VerifyVersionHasReleaseDateListenerTest.php
+++ b/test/Version/VerifyVersionHasReleaseDateListenerTest.php
@@ -14,7 +14,6 @@ use Phly\KeepAChangelog\Config;
 use Phly\KeepAChangelog\Version\TagReleaseEvent;
 use Phly\KeepAChangelog\Version\VerifyVersionHasReleaseDateListener;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -29,7 +28,7 @@ class VerifyVersionHasReleaseDateListenerTest extends TestCase
         $event = $this->prophesize(TagReleaseEvent::class);
         $event->config()->will([$config, 'reveal'])->shouldBeCalled();
         $event->version()->willReturn('1.1.0')->shouldBeCalledTimes(1);
-        $event->taggingFailed()->shouldNotBeCalled();
+        $event->changelogMissingDate()->shouldNotBeCalled();
         $event->output()->shouldNotBeCalled();
 
         $listener = new VerifyVersionHasReleaseDateListener();
@@ -39,23 +38,13 @@ class VerifyVersionHasReleaseDateListenerTest extends TestCase
     public function testNotifiesEventTaggingFailedIfChangelogDoesNotHaveReleaseDate(): void
     {
         $config = $this->prophesize(Config::class);
-        $config->changelogFile()->willReturn(__DIR__ . '/../_files/CHANGELOG.md')->shouldBeCalled();
-
-        /** @var OutputInterface|ObjectProphecy $output */
         $output = $this->prophesize(OutputInterface::class);
-        $output
-            ->writeln(Argument::containingString('Version 2.0.0 does not have a release date'))
-            ->shouldBeCalled();
-        $output
-            ->writeln(Argument::containingString('version:ready'))
-            ->shouldBeCalled();
+        $event  = $this->prophesize(TagReleaseEvent::class);
 
-        /** @var TagReleaseEvent|ObjectProphecy $event */
-        $event = $this->prophesize(TagReleaseEvent::class);
+        $config->changelogFile()->willReturn(__DIR__ . '/../_files/CHANGELOG.md')->shouldBeCalled();
         $event->config()->will([$config, 'reveal'])->shouldBeCalled();
         $event->version()->willReturn('2.0.0')->shouldBeCalled();
-        $event->taggingFailed()->shouldBeCalled();
-        $event->output()->will([$output, 'reveal'])->shouldBeCalled();
+        $event->changelogMissingDate()->shouldBeCalled();
 
         $listener = new VerifyVersionHasReleaseDateListener();
         $this->assertNull($listener($event->reveal()));


### PR DESCRIPTION
Removes `TagReleaseEvent::taggingFailed()` method in favor of the more discrete methods:

- `tagOperationFailed()` (when `git tag` fails)
- `unversionedChangesPresent()` (when changes have not been checked in)
- `changelogMissingDate()` (when changelog for the version does not have a date set yet)

Additionally, it adds some verbiage to the `version:tag` help text that the user may need to `export GPG_TTY=$(tty)` before running the command.

Fixes #86