### PR TITLE
Allow omitting version when tagging and releasing

### DIFF
--- a/src/ListenerProvider.php
+++ b/src/ListenerProvider.php
@@ -121,6 +121,7 @@ class ListenerProvider implements ListenerProviderInterface
         ],
         Version\ReleaseEvent::class                => [
             Version\ReleaseCommandConfigListener::class,
+            Version\DiscoverVersionListener::class,
             Version\VerifyTagExistsListener::class,
             Version\VerifyProviderCanReleaseListener::class,
             Common\IsChangelogReadableListener::class,
@@ -148,6 +149,7 @@ class ListenerProvider implements ListenerProviderInterface
         Version\TagReleaseEvent::class             => [
             Version\TagCommandConfigListener::class,
             Version\CheckTreeForChangesListener::class,
+            Version\DiscoverVersionListener::class,
             Common\ValidateVersionListener::class,
             Common\IsChangelogReadableListener::class,
             Version\VerifyVersionHasReleaseDateListener::class,

--- a/src/Version/DiscoverVersionEventTrait.php
+++ b/src/Version/DiscoverVersionEventTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Version;
+
+trait DiscoverVersionEventTrait
+{
+    public function foundVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function versionNotAccepted(): void
+    {
+        $this->failed = true;
+        $this->output->writeln('<error>No version specified</error>');
+        $this->output->writeln('Please specify a version via the <version> argument.');
+    }
+}

--- a/src/Version/DiscoverVersionListener.php
+++ b/src/Version/DiscoverVersionListener.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Common\ChangelogParser;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+use function array_shift;
+use function count;
+use function is_string;
+use function preg_match;
+use function sprintf;
+
+use const PHP_EOL;
+
+class DiscoverVersionListener
+{
+    /**
+     * Used for testing
+     *
+     * @internal
+     *
+     * @var null|QuestionHelper
+     */
+    public $questionHelper;
+
+    public function __invoke(DiscoverableVersionEventInterface $event): void
+    {
+        $version = $event->version();
+        if (is_string($version) && ! empty($version)) {
+            // Version was provided already
+            return;
+        }
+
+        $readyVersions = $this->getReadyVersions(
+            (new ChangelogParser())
+                ->findAllVersions($event->config()->changelogFile())
+        );
+
+        if (0 === count($readyVersions)) {
+            // No versions found; let version validator flag it as invalid
+            return;
+        }
+
+        $versionToTag = array_shift($readyVersions);
+        $question     = new ConfirmationQuestion(sprintf(
+            "Most recent version in changelog file is <info>%s</info>; use this version? [Y/n]" . PHP_EOL . "> ",
+            $versionToTag
+        ));
+
+        $questionHelper = $this->questionHelper ?: new QuestionHelper();
+        if (! $questionHelper->ask($event->input(), $event->output(), $question)) {
+            $event->versionNotAccepted();
+            return;
+        }
+
+        $event->foundVersion($versionToTag);
+    }
+
+    private function getReadyVersions(iterable $versions): array
+    {
+        $readyVersions = [];
+
+        foreach ($versions as $version => $date) {
+            if (! preg_match('/^\d{4}-\d{2}\-\d{2}$/', $date)) {
+                continue;
+            }
+
+            $readyVersions[] = $version;
+        }
+
+        return $readyVersions;
+    }
+}

--- a/src/Version/DiscoverableVersionEventInterface.php
+++ b/src/Version/DiscoverableVersionEventInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Common\EventInterface;
+use Phly\KeepAChangelog\Common\VersionAwareEventInterface;
+
+interface DiscoverableVersionEventInterface extends
+    EventInterface,
+    VersionAwareEventInterface
+{
+    public function versionNotAccepted(): void;
+
+    public function foundVersion(string $version): void;
+}

--- a/src/Version/ReleaseCommand.php
+++ b/src/Version/ReleaseCommand.php
@@ -61,7 +61,7 @@ EOH;
         $this->setHelp(self::HELP);
         $this->addArgument(
             'version',
-            InputArgument::REQUIRED,
+            InputArgument::OPTIONAL,
             'Version to release'
         );
         $this->addOption(

--- a/src/Version/ReleaseEvent.php
+++ b/src/Version/ReleaseEvent.php
@@ -23,9 +23,12 @@ use Throwable;
 use function gettype;
 use function sprintf;
 
-class ReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterface
+class ReleaseEvent extends AbstractEvent implements
+    ChangelogAwareEventInterface,
+    DiscoverableVersionEventInterface
 {
     use ChangelogProviderTrait;
+    use DiscoverVersionEventTrait;
     use VersionValidationTrait;
 
     /** @var null|ProviderInterface */
@@ -72,6 +75,12 @@ class ReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterface
     public function setReleaseName(string $releaseName): void
     {
         $this->releaseName = $releaseName;
+    }
+
+    public function foundVersion(string $version): void
+    {
+        $this->version = $version;
+        $this->tagName = $this->tagName ?: $version;
     }
 
     public function releaseCreated(string $release): void

--- a/src/Version/TagCommand.php
+++ b/src/Version/TagCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function sprintf;
-
 class TagCommand extends Command
 {
     use CommonConfigOptionsTrait;
@@ -62,7 +60,7 @@ EOH;
     {
         $this->setDescription('Create a new tag, using the relevant changelog entry.');
         $this->setHelp(self::HELP);
-        $this->addArgument('version', InputArgument::REQUIRED, 'Version to tag');
+        $this->addArgument('version', InputArgument::OPTIONAL, 'Version to tag');
         $this->addOption(
             'tagname',
             'a',
@@ -82,17 +80,13 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $version = $input->getArgument('version');
-
-        $output->writeln(sprintf('<info>Preparing to tag version %s</info>', $version));
-
         return $this->dispatcher
                 ->dispatch(new TagReleaseEvent(
                     $input,
                     $output,
                     $this->dispatcher,
-                    $version,
-                    $input->getOption('tagname') ?: $version
+                    $input->getArgument('version'),
+                    $input->getOption('tagname')
                 ))
                 ->failed()
                     ? 1

--- a/src/Version/TagReleaseEvent.php
+++ b/src/Version/TagReleaseEvent.php
@@ -20,26 +20,29 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
 
-class TagReleaseEvent extends AbstractEvent implements ChangelogAwareEventInterface
+class TagReleaseEvent extends AbstractEvent implements
+    ChangelogAwareEventInterface,
+    DiscoverableVersionEventInterface
 {
     use ChangelogProviderTrait;
+    use DiscoverVersionEventTrait;
     use VersionValidationTrait;
 
-    /** @var string */
+    /** @var null|string */
     private $tagName;
 
     public function __construct(
         InputInterface $input,
         OutputInterface $output,
         EventDispatcherInterface $dispatcher,
-        string $version,
-        string $tagName
+        ?string $version,
+        ?string $tagName
     ) {
         $this->input      = $input;
         $this->output     = $output;
         $this->dispatcher = $dispatcher;
         $this->version    = $version;
-        $this->tagName    = $tagName;
+        $this->tagName    = $tagName ?: $version;
     }
 
     public function isPropagationStopped(): bool

--- a/src/Version/TagReleaseListener.php
+++ b/src/Version/TagReleaseListener.php
@@ -21,11 +21,15 @@ class TagReleaseListener
 {
     public function __invoke(TagReleaseEvent $event): void
     {
+        $version = $event->version();
+
+        $event->output()->writeln(sprintf('<info>Preparing to tag version %s</info>', $version));
+
         if (
             ! $this->tagWithChangelog(
                 $event->tagName(),
                 $event->package(),
-                $event->version(),
+                $version,
                 $event->changelog()
             )
         ) {

--- a/test/Version/DiscoverVersionListenerTest.php
+++ b/test/Version/DiscoverVersionListenerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @see       https://github.com/phly/keep-a-changelog for the canonical source repository
+ * @copyright Copyright (c) 2019 Matthew Weier O'Phinney
+ * @license   https://github.com/phly/keep-a-changelog/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\KeepAChangelog\Version;
+
+use Phly\KeepAChangelog\Config;
+use Phly\KeepAChangelog\Version\DiscoverVersionListener;
+use Phly\KeepAChangelog\Version\TagReleaseEvent;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class DiscoverVersionListenerTest extends TestCase
+{
+    public function testReturnsEarlyWhenEventHasVersionComposed(): void
+    {
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->version()->willReturn('1.2.3')->shouldBeCalled();
+
+        $listener = new DiscoverVersionListener();
+
+        $this->assertNull($listener($event->reveal()));
+
+        $event->versionNotAccepted()->shouldNotHaveBeenCalled();
+        $event->foundVersion(Argument::any())->shouldNotHaveBeenCalled();
+    }
+
+    public function testReturnsEarlyWhenEventDoesNotHaveVersionComposedAndChangelogDoesNotHaveDatedEntries(): void
+    {
+        $config = $this->prophesize(Config::class);
+        $config
+            ->changelogFile()
+            ->willReturn(__DIR__ . '/../_files/CHANGELOG-MULTIPLE-UNRELEASED.md')
+            ->shouldBeCalled();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->version()->willReturn(null)->shouldBeCalled();
+        $event->config()->will([$config, 'reveal'])->shouldBeCalled();
+
+        $listener = new DiscoverVersionListener();
+
+        $this->assertNull($listener($event->reveal()));
+
+        $event->versionNotAccepted()->shouldNotHaveBeenCalled();
+        $event->foundVersion(Argument::any())->shouldNotHaveBeenCalled();
+    }
+
+    public function testNotifiesEventOfInvalidVersionSpecifiedWhenQuestionAnsweredIncorrectly(): void
+    {
+        $config = $this->prophesize(Config::class);
+        $config
+            ->changelogFile()
+            ->willReturn(__DIR__ . '/../_files/CHANGELOG-WITH-RELEASED-VERSIONS.md')
+            ->shouldBeCalled();
+
+        $input  = $this->prophesize(InputInterface::class)->reveal();
+        $output = $this->prophesize(OutputInterface::class)->reveal();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->version()->willReturn(null)->shouldBeCalled();
+        $event->config()->will([$config, 'reveal'])->shouldBeCalled();
+        $event->input()->willReturn($input)->shouldBeCalled();
+        $event->output()->willReturn($output)->shouldBeCalled();
+
+        $event->versionNotAccepted()->shouldBeCalled();
+        $event->foundVersion(Argument::any())->shouldNotBeCalled();
+
+        $questionHelper = $this->prophesize(QuestionHelper::class);
+        $questionHelper
+            ->ask($input, $output, Argument::type(ConfirmationQuestion::class))
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $listener                 = new DiscoverVersionListener();
+        $listener->questionHelper = $questionHelper->reveal();
+
+        $this->assertNull($listener($event->reveal()));
+    }
+
+    public function testNotifiesEventOfVersionWhenUserProvidesIt(): void
+    {
+        $config = $this->prophesize(Config::class);
+        $config
+            ->changelogFile()
+            ->willReturn(__DIR__ . '/../_files/CHANGELOG-WITH-RELEASED-VERSIONS.md')
+            ->shouldBeCalled();
+
+        $input  = $this->prophesize(InputInterface::class)->reveal();
+        $output = $this->prophesize(OutputInterface::class)->reveal();
+
+        $event = $this->prophesize(TagReleaseEvent::class);
+        $event->version()->willReturn(null)->shouldBeCalled();
+        $event->config()->will([$config, 'reveal'])->shouldBeCalled();
+        $event->input()->willReturn($input)->shouldBeCalled();
+        $event->output()->willReturn($output)->shouldBeCalled();
+
+        $event->versionNotAccepted()->shouldNotBeCalled();
+        $event->foundVersion('2.0.0')->shouldBeCalled();
+
+        $questionHelper = $this->prophesize(QuestionHelper::class);
+        $questionHelper
+            ->ask($input, $output, Argument::type(ConfirmationQuestion::class))
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $listener                 = new DiscoverVersionListener();
+        $listener->questionHelper = $questionHelper->reveal();
+
+        $this->assertNull($listener($event->reveal()));
+    }
+}

--- a/test/_files/CHANGELOG-NO-UNRELEASED.md
+++ b/test/_files/CHANGELOG-NO-UNRELEASED.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 2.0.0 - 2020-09-15
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.1.0 - 2018-03-23
+
+### Added
+
+- Added a new feature.
+
+### Changed
+
+- Made some changes.
+
+### Deprecated
+
+- Nothing was deprecated.
+
+### Removed
+
+- Nothing was removed.
+
+### Fixed
+
+- Fixed some bugs.
+
+## 0.1.0 - 2018-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.

--- a/test/_files/CHANGELOG-WITH-RELEASED-VERSIONS.md
+++ b/test/_files/CHANGELOG-WITH-RELEASED-VERSIONS.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 2.0.0 - 2020-09-15
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.2.0 - 2020-06-01
+
+### Added
+
+- Added a new feature.
+
+### Changed
+
+- Made some changes.
+
+### Deprecated
+
+- Nothing was deprecated.
+
+### Removed
+
+- Nothing was removed.
+
+### Fixed
+
+- Fixed some bugs.
+
+## 0.1.1 - 2020-01-01
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+


### PR DESCRIPTION
Updates the `version:tag` and `version:release` commands to make their `version` arguments optional. When not present, a new listener will try and locate the latest release with a date associated, and present a confirmation prompt to the user asking if that's the one they want to use. Since later listeners will fail hard if the tag and/or release already exists, this acts as a sanity check in most instances.

Fixes #84