### PR TITLE
qa: allow use of symfony/console 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ocramius/package-versions": "^1.5.1 || ^2.1.0",
         "php-http/guzzle7-adapter": "^0.1.1",
         "psr/event-dispatcher": "^1.0.0",
-        "symfony/console": "^5.2.1"
+        "symfony/console": "^5.2.1 || ^6.0"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,10 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4.7"
+        },
+        "allow-plugins": {
+            "captainhook/plugin-composer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3600edf805d6c2c155ac98ec9a7b680b",
+    "content-hash": "5c54ed47dc59cbed85fabad90f8fe1a1",
     "packages": [
         {
             "name": "clue/stream-filter",


### PR DESCRIPTION
Currently, if you attempt to install symfony/console 6.x into a project that also requires phly/keep-a-changelog, you will receive a Composer dependency resolution error. This is because phly/keep-a-changelog uses `^5.2.1` as the version constraint for symfony/console.

This PR allows projects using this package the ability to upgrade to the new 6.x series of symfony/console (or it allows packages already using symfony/console 6.x the ability to install phly/keep-a-changelog).
