### PR TITLE
Ensure release target commands work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "composer-runtime-api": "^2.0",
-        "knplabs/github-api": "^3.0",
+        "knplabs/github-api": "^3.4",
         "laminas/laminas-diactoros": "^2.4.1",
         "m4tthumphrey/php-gitlab-api": "^11.0",
         "php-http/guzzle7-adapter": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "494ca9767cff7dae576596e0e149a39d",
+    "content-hash": "18999e441fa10376fe93ad89ba56258c",
     "packages": [
         {
             "name": "clue/stream-filter",

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Phly\KeepAChangelog\Provider;
 
+use Github\AuthMethod;
 use Github\Client as GitHubClient;
 use Github\Exception\ExceptionInterface as GithubException;
 use Phly\KeepAChangelog\Common\ValidateVersionListener;
@@ -257,7 +258,7 @@ class GitHub implements MilestoneAwareProviderInterface, ProviderInterface
         $client = self::DEFAULT_URL === $this->url
             ? new GitHubClient()
             : new GitHubClient(null, null, $this->url);
-        $client->authenticate($this->token, GitHubClient::AUTH_HTTP_TOKEN);
+        $client->authenticate($this->token, AuthMethod::ACCESS_TOKEN);
 
         return $client;
     }


### PR DESCRIPTION
Discovered when releasing 2.12.0: In 3.4 of knplabs/github-api, the `Client::AUTH_*` constants were deprecated in favor of `AuthMethod::*` constants; in later versions in the 3.x release, the original constants were **removed** (a BC break).

This patch updates to use the `AuthMethod` constants, and pins to 3.4 and later to ensure they work.
